### PR TITLE
fixes: missing foreign key, feat: 'add' procedures for most of the tables

### DIFF
--- a/db/add_administrator.sql
+++ b/db/add_administrator.sql
@@ -1,0 +1,9 @@
+DROP PROCEDURE IF EXISTS add_administrator;
+DELIMITER //
+CREATE PROCEDURE add_administrator (IN admin_email VARCHAR(255), IN admin_password VARCHAR(255))    
+BEGIN    
+    DECLARE account_exists int DEFAULT 0;  
+    SELECT COUNT(*) INTO account_exists FROM administrators WHERE administrators.email = admin_email;
+    INSERT INTO `administrators`(`email`, `password`) VALUES (admin_email, admin_password);
+END//
+DELIMITER ;

--- a/db/add_administrator.sql
+++ b/db/add_administrator.sql
@@ -4,6 +4,8 @@ CREATE PROCEDURE add_administrator (IN admin_email VARCHAR(255), IN admin_passwo
 BEGIN    
     DECLARE account_exists int DEFAULT 0;  
     SELECT COUNT(*) INTO account_exists FROM administrators WHERE administrators.email = admin_email;
-    INSERT INTO `administrators`(`email`, `password`) VALUES (admin_email, admin_password);
+    IF account_exists = 0 THEN
+        INSERT INTO `administrators`(`email`, `password`) VALUES (admin_email, admin_password);
+    END IF;
 END//
 DELIMITER ;

--- a/db/add_allowed_respondent.sql
+++ b/db/add_allowed_respondent.sql
@@ -1,0 +1,13 @@
+DROP PROCEDURE IF EXISTS add_allowed_respondent;
+DELIMITER //
+CREATE PROCEDURE add_allowed_respondent (IN respondentId int, IN surveyId int)    
+BEGIN    
+    DECLARE entry_exists int DEFAULT 0;  
+    SELECT COUNT(*) INTO entry_exists FROM allowed_respondents 
+    WHERE allowed_respondents.respondentId = respondentId 
+        AND allowed_respondents.surveyId = surveyId;
+    IF entry_exists = 0 THEN
+        INSERT INTO `allowed_respondents`(`respondentId`, `surveyId`) VALUES (respondentId, surveyId);
+    END IF;
+END//
+DELIMITER ;

--- a/db/add_respondent.sql
+++ b/db/add_respondent.sql
@@ -1,0 +1,11 @@
+DROP PROCEDURE IF EXISTS add_respondent;
+DELIMITER //
+CREATE PROCEDURE add_respondent (IN respondent_email VARCHAR(255))    
+BEGIN    
+    DECLARE account_exists int DEFAULT 0;  
+    SELECT COUNT(*) INTO account_exists FROM respondents WHERE respondents.email = respondent_email;
+    IF account_exists = 0 THEN
+        INSERT INTO `respondents`(`email`) VALUES (respondent_email);
+    END IF;
+END//
+DELIMITER ;

--- a/db/add_response.sql
+++ b/db/add_response.sql
@@ -1,0 +1,13 @@
+DROP PROCEDURE IF EXISTS add_response;
+DELIMITER //
+CREATE PROCEDURE add_response (IN respondentId int, IN surveyId int)    
+BEGIN    
+    DECLARE entry_exists int DEFAULT 0;  
+    SELECT COUNT(*) INTO entry_exists FROM responses 
+    WHERE responses.respondentId = respondentId 
+        AND responses.surveyId = surveyId;
+    IF entry_exists = 0 THEN
+        INSERT INTO `responses`(`respondentId`, `surveyId`) VALUES (respondentId, surveyId);
+    END IF;
+END//
+DELIMITER ;

--- a/db/add_survey
+++ b/db/add_survey
@@ -1,0 +1,28 @@
+DROP PROCEDURE IF EXISTS add_survey;
+DELIMITER //
+CREATE PROCEDURE add_survey (
+    IN survey_owner_id int,
+    IN survey_title VARCHAR(255), 
+    IN survey_description VARCHAR(255), 
+    IN survey_start_date DATE, 
+    IN survey_end_date DATE,
+    IN survey_creation_date DATE)    
+BEGIN   
+    INSERT INTO `surveys`(
+        `survey_ownerId`, 
+        `title`,
+        `description`,
+        `startDate`,
+        `endDate`,
+        `creationDate`,
+        `modificationDate`) 
+        VALUES (
+            survey_owner_id, 
+            survey_title,
+            survey_description,
+            survey_start_date,
+            survey_end_date,
+            survey_creation_date,
+            CURDATE());
+END//
+DELIMITER ;

--- a/db/add_user.sql
+++ b/db/add_user.sql
@@ -1,0 +1,11 @@
+DROP PROCEDURE IF EXISTS add_user;
+DELIMITER //
+CREATE PROCEDURE add_user (IN user_email VARCHAR(255), IN user_password VARCHAR(255))    
+BEGIN   
+    DECLARE user_exists int DEFAULT 0;  
+    SELECT COUNT(*) INTO user_exists FROM users WHERE users.email = user_email;
+    IF user_exists = 0 THEN
+        INSERT INTO `users`(`email`, `password`) VALUES (user_email, user_password);
+    END IF;
+END//
+DELIMITER ;

--- a/db/add_user.sql
+++ b/db/add_user.sql
@@ -2,9 +2,9 @@ DROP PROCEDURE IF EXISTS add_user;
 DELIMITER //
 CREATE PROCEDURE add_user (IN user_email VARCHAR(255), IN user_password VARCHAR(255))    
 BEGIN   
-    DECLARE user_exists int DEFAULT 0;  
-    SELECT COUNT(*) INTO user_exists FROM users WHERE users.email = user_email;
-    IF user_exists = 0 THEN
+    DECLARE account_exists int DEFAULT 0;  
+    SELECT COUNT(*) INTO account_exists FROM users WHERE users.email = user_email;
+    IF account_exists = 0 THEN
         INSERT INTO `users`(`email`, `password`) VALUES (user_email, user_password);
     END IF;
 END//

--- a/db/create_db.sql
+++ b/db/create_db.sql
@@ -105,6 +105,7 @@ CREATE TABLE scale_answers(
     answerId int NOT NULL,
     scale_question_questionsId int NOT NULL,
     value int,
+    FOREIGN KEY (answerId) REFERENCES answers(id),
     FOREIGN KEY (scale_question_questionsId) REFERENCES scale_questions(questionId)
 );
 


### PR DESCRIPTION
Changed:
Added procedures:
- add allowed respondent,
- add respondent,
- add response,
- add user,
- add administrator

Fixed:
- missing foreign key in scale_answers table,
- added missing check to see whether admin account already exists