### PR TITLE
feat: finished my surveys, admin login view, fix: sidebar bugs

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -3,42 +3,26 @@ module.exports = {
   env: {
     node: true
   },
-  "extends": [
-    "plugin:vue/recommended",
-    "eslint:recommended"
-  ],
+  extends: [ "plugin:vue/recommended", "eslint:recommended" ],
   parserOptions: {
     parser: "@babel/eslint-parser",
-    "sourceType": "module",
-    "allowImportExportEverywhere": true,
-    "ecmaVersion": 2019
+    sourceType: "module",
+    allowImportExportEverywhere: true,
+    ecmaVersion: 2019
   },
   rules: {
     "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
     "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
     "comma-dangle": "warn",
-    "quotes": [
-      "warn",
-      "double"
-    ],
-    "linebreak-style": [
-      "warn",
-      "unix"
-    ],
-    "array-bracket-spacing": [
-      "warn",
-      "always"
-    ],
-    "semi": [
-      "warn",
-      "always"
-    ],
-    "eol-last": [
-      "warn",
-      "always"
-    ],
+    quotes: [ "warn", "double" ],
+    "linebreak-style": [ "warn", "unix" ],
+    "array-bracket-spacing": [ "warn", "always" ],
+    semi: [ "warn", "always" ],
+    "eol-last": [ "warn", "always" ],
     "vue/multi-word-component-names": "warn",
-    "vue/no-v-text-v-html-on-component": "warn"
+    "vue/no-v-text-v-html-on-component": "warn",
+    "vue/no-unused-vars": "warn",
+    "vue/valid-v-slot": "warn"
   },
   overrides: [
     {
@@ -52,5 +36,3 @@ module.exports = {
     }
   ]
 };
-
-

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -15,8 +15,8 @@ export default {
     htmlAttrs: { lang: "en" },
     meta: [
       { charset: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1" },
-    ],
-  },
+      { name: "viewport", content: "width=device-width, initial-scale=1" }
+    ]
+  }
 };
 </script>

--- a/ui/src/assets/json/lorem-ipsum.json
+++ b/ui/src/assets/json/lorem-ipsum.json
@@ -1,0 +1,3 @@
+{
+  "long": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+}

--- a/ui/src/components/BottomSheet.vue
+++ b/ui/src/components/BottomSheet.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-bottom-sheet
+    v-model="show"
+    persistent
+  >
+    <v-sheet
+      class="text-center"
+      :height="windowHeight-100"
+    >
+      <v-btn
+        class="mt-6"
+        text
+        color="error"
+        @click="show = !show"
+      >
+        close
+      </v-btn>
+      <slot name="content" />
+    </v-sheet>
+  </v-bottom-sheet>
+</template>
+
+<script>
+export default {
+  name: "BottomSheet",
+  props: {
+     value: Boolean
+  },
+  computed: {
+    show: {
+      get () {
+        return this.value;
+      },
+      set (value) {
+         this.$emit("input", value);
+      }
+    }
+  }
+};
+</script>

--- a/ui/src/components/ContentCard.vue
+++ b/ui/src/components/ContentCard.vue
@@ -1,9 +1,9 @@
 <template>
   <v-card
     v-bind="$attrs"
-    v-on="$listeners"
     class="content-card text-center"
     :class="{'--is-mobile': isMobile, 'elevated-2': !isMobile}"
+    v-on="$listeners"
   >
     <v-container>
       <v-row justify="center">
@@ -15,15 +15,15 @@
             {{ description }}
           </v-card-text>
           <v-img
-            class="mx-auto"
             v-if="image"
+            class="mx-auto"
             :src="image"
             :max-width="maxImageWidth"
             :max-height="maxImageHeight"
           />
           <v-btn
-            flat
             v-if="showBackToHomeButton"
+            flat
             class="v-btn--primary content-card__home-button"
             to="/"
             height="53"
@@ -46,29 +46,29 @@ export default {
   props: {
     title: {
       type: String,
-      default: "",
+      default: ""
     },
     description: {
       type: String,
-      default: "",
+      default: ""
     },
     image: {
       type: String,
-      default: null,
+      default: null
     },
     maxImageWidth: {
       type: Number,
-      default: 100,
+      default: 100
     },
     maxImageHeight: {
       type: Number,
-      default: 100,
+      default: 100
     },
     showBackToHomeButton: {
       type: Boolean,
-      default: true,
-    },
-  },
+      default: true
+    }
+  }
 };
 </script>
 

--- a/ui/src/components/ErrorMessage.vue
+++ b/ui/src/components/ErrorMessage.vue
@@ -14,9 +14,9 @@ export default {
   props: {
     text: {
       type: String,
-      default: "This field has errors",
-    },
-  },
+      default: "This field has errors"
+    }
+  }
 };
 </script>
 <style lang="scss">

--- a/ui/src/components/Links.vue
+++ b/ui/src/components/Links.vue
@@ -27,14 +27,14 @@ export default {
     links: [
       {
         href: "/privacy-policy",
-        text: "Privacy Policy",
+        text: "Privacy Policy"
       },
       {
         href: "/terms-and-conditions",
-        text: "Terms and Conditions",
-      },
-    ],
-  }),
+        text: "Terms and Conditions"
+      }
+    ]
+  })
 };
 </script>
 

--- a/ui/src/components/MaterialCard.vue
+++ b/ui/src/components/MaterialCard.vue
@@ -72,32 +72,32 @@ export default {
   props: {
     color: {
       type: String,
-      default: "white",
+      default: "white"
     },
     fullHeader: {
       type: Boolean,
-      default: true,
+      default: true
     },
     heading: {
       type: String,
-      default: "",
+      default: ""
     },
     icon: {
       type: String,
-      default: "",
+      default: ""
     },
     iconSmall: {
       type: Boolean,
-      default: false,
+      default: false
     },
     subtitle: {
       type: String,
-      default: "",
+      default: ""
     },
     title: {
       type: String,
-      default: "",
-    },
+      default: ""
+    }
   },
 
   computed: {
@@ -111,8 +111,8 @@ export default {
         this.$slots.title ||
         this.$slots.subtitle
       );
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/ui/src/components/Modal.vue
+++ b/ui/src/components/Modal.vue
@@ -1,0 +1,121 @@
+<template>
+  <v-dialog
+    v-model="show"
+    class="modal"
+    max-width="600px"
+    persistent
+  >
+    <v-card class="pa-0">
+      <v-card-actions v-if="isCloseButtonShown">
+        <v-row
+          row
+          d-flex
+          nowrap
+          align="right"
+          justify="end"
+          class="pa-4"
+        >
+          <v-btn
+            icon
+            text
+            small
+            fab
+            @click.stop="show=false"
+          >
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-row>
+      </v-card-actions>
+      <!-- use slot if default slot is given, else use default template -->
+      <slot v-if="!!$slots.default" />
+      <template v-else>
+        <v-card-title v-if="isTitleShown">
+          {{ title || "Title" | capitalize }}
+        </v-card-title>
+        <v-card-text v-if="isContentShown">
+          {{ content }}
+        </v-card-text>
+        <v-card-actions v-if="isFooterShown">
+          <v-row justify="end">
+            <v-col
+              cols="auto"
+              class="text-right"
+            >
+              <v-btn
+                text
+                @click.stop="show=false"
+              >
+                Close
+              </v-btn>
+              <v-btn
+                color="primary"
+                text
+                class="text-uppercase"
+                @click="onPrimaryActionButtonClick"
+              >
+                {{ primaryActionButtonText || "OK" }}
+              </v-btn>
+            </v-col>
+          </v-row>
+        </v-card-actions>
+      </template>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  name: "Modal",
+  props: {
+    value: Boolean,
+    title: {
+      type: String,
+      default: ""
+    },
+    content: {
+      type: String,
+      default: ""
+    },
+    primaryActionButtonText: {
+      type: String,
+      default: ""
+    },
+    isTitleShown: {
+      type: Boolean,
+      default: true
+    },
+    isContentShown: {
+      type: Boolean,
+      default: true
+    },
+    isFooterShown: {
+      type: Boolean,
+      default: true
+    },
+    isCloseButtonShown: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    show: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit("input", value);
+      }
+    }
+  },
+  methods: {
+    onPrimaryActionButtonClick() {
+      this.$emit("click:primary-action", true);
+    }
+  }
+};
+</script>
+<style lang="scss">
+.v-dialog {
+  overflow: hidden;
+}
+</style>

--- a/ui/src/filters/index.js
+++ b/ui/src/filters/index.js
@@ -1,0 +1,10 @@
+import Vue from "vue";
+import { convertToStandardDate } from "@util/dates.js";
+
+Vue.filter("capitalize", function (value) {
+  if (!value) return "";
+  value = value.toString();
+  return value.charAt(0).toUpperCase() + value.slice(1);
+});
+
+Vue.filter("standardDate", convertToStandardDate);

--- a/ui/src/layouts/default/AppBar.vue
+++ b/ui/src/layouts/default/AppBar.vue
@@ -10,12 +10,12 @@
     flat
   >
     <v-app-bar-nav-icon
-      v-if="isDrawerShown"
-      class="hidden-md-and-up"
+      v-if="isDrawerShown && isMobile"
       @click="drawer = !drawer"
     />
+
     <v-btn
-      class="logo test"
+      class="logo"
       text
       plain
       to="/"
@@ -32,13 +32,8 @@ import { mapGetters } from "vuex";
 export default {
   name: "DefaultBar",
   computed: {
-    ...sync("app", [
-      "drawer",
-      "mini"
-    ]),
-    ...mapGetters("user", [
-      "hasLoggedIn"
-    ]),
+    ...sync("app", [ "drawer", "mini" ]),
+    ...mapGetters("user", [ "hasLoggedIn" ]),
     name: get("route/name"),
     isDrawerShown() {
       return this.hasLoggedIn;
@@ -49,10 +44,18 @@ export default {
 <style lang="scss">
 #default-app-bar {
   .logo {
-    background-color: transparent; 
+    background-color: transparent;
     color: $white;
     text-transform: none;
+    padding: 0;
+
+    > .v-btn__content {
+      opacity: 1;
+    }
+  }
+
+  .v-icon {
+    color: $white;
   }
 }
-
 </style>

--- a/ui/src/layouts/default/Drawer.vue
+++ b/ui/src/layouts/default/Drawer.vue
@@ -2,18 +2,17 @@
   <v-navigation-drawer
     id="default-drawer"
     v-model="drawer"
-    class="elevated-6"
+    class="default-drawer elevated-6"
     clipped
-    :floating="isMobile"
+    :permanent="!isMobile"
     :mini-variant.sync="mini"
-    mini-variant-width="80"
-    :width="width"
+    :mini-variant-width="isMobile && !drawer? 0 : 80"
+    :width="isMobile && !drawer ? 0 : width"
   >
-    <div class="px-2">
+    <div class="default-drawer__wrapper">
       <default-drawer-header />
       <v-divider class="mx-3 mb-2" />
       <default-list :items="items" />
-      <v-divider class="mx-3 mb-2" />
       <default-drawer-toggle />
     </div>
   </v-navigation-drawer>
@@ -39,27 +38,46 @@ export default {
       import(
         /* webpackChunkName: "default-drawer-toggle" */
         "./widgets/DrawerToggle"
-      ),
+      )
   },
   computed: {
-    ...get("user", ["items"]),
-    ...sync("app", ["drawer", "mini"]),
+    ...get("user", [ "items" ]),
+    ...sync("app", [ "drawer", "mini" ]),
     width() {
       return this.isMobile ? (this.drawer ? 260 : 0) : 260;
-    },
+    }
   },
   watch: {
     isMobile(val) {
       this.drawer = !val;
-    },
-  },
+    }
+  }
 };
 </script>
 
 <style lang="scss">
-#default-drawer {
+.default-drawer {
+  padding: calculate-space(10) 0;
+  box-shadow: $sidebar-box-shadow;
+
+  .v-list {
+    padding: 0;
+
+    &--nav {
+      .v-list-item {
+        border-radius: 0;
+      }
+    }
+  }
+
   .v-list-item {
     margin-bottom: 8px;
+    border-radius: 0;
+
+    &--active {
+      color: map-get($theme-colors, "primary") !important;
+      background-color: map-get($overlays, "primary") !important;
+    }
   }
 
   .v-list-item::before,
@@ -74,10 +92,8 @@ export default {
     margin-left: 4px;
   }
 
-  &.v-navigation-drawer--mini-variant {
-    .v-list-item {
-      justify-content: flex-start !important;
-    }
+  .v-navigation-drawer__border {
+    background-color: none;
   }
 }
 </style>

--- a/ui/src/layouts/default/Footer.vue
+++ b/ui/src/layouts/default/Footer.vue
@@ -28,8 +28,8 @@ export default {
   computed: {
     logo() {
       return require("@assets/svg/logo.svg");
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/ui/src/layouts/default/Index.vue
+++ b/ui/src/layouts/default/Index.vue
@@ -37,11 +37,11 @@ export default {
       import(
         /* webpackChunkName: "default-view" */
         "./View"
-      ),
+      )
   },
   computed: {
-    ...sync("app", ["drawer", "mini"]),
-  },
+    ...sync("app", [ "drawer", "mini" ])
+  }
 };
 </script>
 <style lang="scss">

--- a/ui/src/layouts/default/List.vue
+++ b/ui/src/layouts/default/List.vue
@@ -15,7 +15,14 @@
       <default-list-item
         v-else
         :key="`item-${i}`"
+        class="default-list-item"
+        :class="{'--is-last-before-separation': item.isLastBeforeSeparation}"
         :item="item"
+      />
+      <v-divider
+        v-if="item.isLastBeforeSeparation"
+        :key="`divider-${i}`"
+        class="mx-3 mb-2"
       />
     </template>
   </v-list>
@@ -38,3 +45,12 @@ export default {
   }
 };
 </script>
+
+<style lang="scss">
+
+.default-list-item {
+  &.--is-last-before-separation {
+    margin-bottom: 80px !important;
+  }
+}
+</style>

--- a/ui/src/layouts/default/View.vue
+++ b/ui/src/layouts/default/View.vue
@@ -19,18 +19,19 @@ export default {
   name: "DefaultView",
   computed: {
     hasPurpleBackground() {
-      const allRouteNames = ["general-landing", "general-admin-login"];
+      const allRouteNames = [ "general-landing" ];
       const desktopOnlyRouteNames = [
         "general-user-signup",
         "general-user-login",
+        "general-admin-login"
       ];
       return this.isMobile
         ? allRouteNames.includes(this.$route.name)
         : allRouteNames
             .concat(desktopOnlyRouteNames)
             .includes(this.$route.name);
-    },
-  },
+    }
+  }
 };
 </script>
 <style lang="scss">

--- a/ui/src/layouts/default/widgets/DrawerHeader.vue
+++ b/ui/src/layouts/default/widgets/DrawerHeader.vue
@@ -1,17 +1,28 @@
 <template>
-  <v-list-item class="mb-0 justify-space-between pl-3">
-    <v-list-item-avatar>
-      <span>
-        {{ userData.email[0] || "e" }}
-      </span>
-    </v-list-item-avatar>
+  <div class="drawer-header">
+    <v-list-item class="mb-0 justify-space-between drawer-header__list-item">
+      <v-img
+        v-if="!mini"
+        :src="require('@assets/svg/profile_picture.svg')"
+        max-height="40"
+        max-width="40"
+      />
+      <v-list-item-avatar
+        v-if="mini"
+        class="drawer-header__avatar"
+      >
+        <span class="email">
+          {{ email[0] }}
+        </span>
+      </v-list-item-avatar>
 
-    <v-list-item-content class="pl-2">
-      <v-list-item-title class="text-body">
-        {{ userData.email || "email@email.com" }} 
-      </v-list-item-title>
-    </v-list-item-content>
-  </v-list-item>
+      <v-list-item-content class="pl-2">
+        <v-list-item-title class="text-body">
+          {{ email }}
+        </v-list-item-title>
+      </v-list-item-content>
+    </v-list-item>
+  </div>
 </template>
 
 <script>
@@ -19,11 +30,34 @@ import { get } from "vuex-pathify";
 
 export default {
   name: "DefaultDrawerHeader",
-  computed: { 
-    userData() {
-      const defaultUserData = {email: ""};
-      return {...defaultUserData, ...get("user/userData")};
-    } 
+  computed: {
+    ...get("user", [ "userData" ]),
+    ...get("app", [ "mini" ]),
+    email() {
+      return this.userData.email || "email@email.com";
+    }
   }
 };
 </script>
+
+
+<style scoped lang="scss">
+.drawer-header {
+  margin: 20px 0;
+
+  &__list-item {
+    display: flex;
+    flex-flow: column;
+  }
+
+  &__avatar {
+    justify-content: center;
+    color: $white;
+    background-color: $black;
+  }
+
+  .v-list-item__title {
+    font-weight: 500;
+  }
+}
+</style>

--- a/ui/src/layouts/default/widgets/DrawerToggle.vue
+++ b/ui/src/layouts/default/widgets/DrawerToggle.vue
@@ -1,15 +1,20 @@
 <template>
-  <v-btn
-    class="ml-3 mr-4"
-    elevation="1"
-    fab
-    small
-    @click="mini = !mini"
+  <div
+    class="drawer-toggle"
+    :class="{'--is-mini': mini}"
   >
-    <v-icon>
-      {{ mini ? 'mdi-chevron-right' : 'mdi-chevron-left' }}
-    </v-icon>
-  </v-btn>
+    <v-btn
+      text
+      fab
+      small
+      class="drawer-toggle__button"
+      @click="mini = !mini"
+    >
+      <v-icon>
+        {{ mini ? 'mdi-chevron-right' : 'mdi-chevron-left' }}
+      </v-icon>
+    </v-btn>
+  </div>
 </template>
 
 <script>
@@ -19,8 +24,22 @@ export default {
   name: "DefaultDrawerToggle",
 
   computed: {
-
     mini: sync("app/mini")
   }
 };
 </script>
+<style lang="scss">
+.drawer-toggle {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  padding: 0 calculate-space(2);
+
+  &.--is-mini {
+    justify-content: center;
+  }
+
+  &__button {
+  }
+}
+</style>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -8,11 +8,11 @@ import axiosConfig from "./api/config.js";
 import { sync } from "vuex-router-sync";
 import "./plugins";
 import "./mixins";
+import "./filters";
 import "./registerServiceWorker";
 
 Vue.config.productionTip = false;
 Vue.prototype.$axios = axios.create(axiosConfig);
-
 
 sync(store, router);
 
@@ -20,5 +20,5 @@ new Vue({
   router,
   vuetify,
   store,
-  render: h => h(App)
+  render: (h) => h(App)
 }).$mount("#app");

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -1,48 +1,174 @@
 import Vue from "vue";
 import Router from "vue-router";
 import { trailingSlash } from "@/util/helpers";
-import {
-  layout
-} from "@/util/routes";
+import { layout } from "@/util/routes";
 import PageNotFoundView from "@views/PageNotFoundView.vue";
 import store from "@store/index.js";
+import Cookies from "js-cookie";
 
 Vue.use(Router);
 
 const userRoutes = [
   layout("Default", [
-    { path: "/user/surveys", name: "user-surveys", component: () => import(/* webpackChunkName: "user-surveys" */ "@views/user/surveys/SurveysView.vue") },
-    { path: "/user/surveys/:id/edit", name: "user-survey-edit", component: () => import(/* webpackChunkName: "user-survey-edit" */ "@views/user/survey-edit/SurveyEditView.vue") },
-    { path: "/user/surveys/:id/", name: "user-survey-detail", component: () => import(/* webpackChunkName: "user-survey-detail" */ "@views/user/survey-detail/SurveyDetailView.vue") },
-    { path: "/user/settings", name: "user-settings", component: () => import(/* webpackChunkName: "user-settings" */ "@views/user/settings/SettingsView.vue") }
+    {
+      path: "/user/surveys",
+      name: "user-surveys",
+      component: () =>
+        import(
+          /* webpackChunkName: "user-surveys" */ "@views/user/surveys/SurveysView.vue"
+        )
+    },
+    {
+      path: "/user/surveys/:id/edit",
+      name: "user-survey-edit",
+      component: () =>
+        import(
+          /* webpackChunkName: "user-survey-edit" */ "@views/user/survey-edit/SurveyEditView.vue"
+        )
+    },
+    {
+      path: "/user/surveys/:id/",
+      name: "user-survey-detail",
+      component: () =>
+        import(
+          /* webpackChunkName: "user-survey-detail" */ "@views/user/survey-detail/SurveyDetailView.vue"
+        )
+    },
+    {
+      path: "/user/settings",
+      name: "user-settings",
+      component: () =>
+        import(
+          /* webpackChunkName: "user-settings" */ "@views/user/settings/SettingsView.vue"
+        )
+    }
   ])
 ];
 
 const adminRoutes = [
   layout("Default", [
-    { path: "/admin/surveys", name: "admin-surveys", component: () => import(/* webpackChunkName: "admin-surveys" */ "@views/admin/surveys/SurveysView.vue") },
-    { path: "/admin/users", name: "admin-users", component: () => import(/* webpackChunkName: "admin-users" */ "@views/admin/users/UsersView.vue") },
-    { path: "/admin/settings", name: "admin-settings", component: () => import(/* webpackChunkName: "admin-settings" */ "@views/admin/settings/SettingsView.vue") }
+    {
+      path: "/admin/surveys",
+      name: "admin-surveys",
+      component: () =>
+        import(
+          /* webpackChunkName: "admin-surveys" */ "@views/admin/surveys/SurveysView.vue"
+        )
+    },
+    {
+      path: "/admin/users",
+      name: "admin-users",
+      component: () =>
+        import(
+          /* webpackChunkName: "admin-users" */ "@views/admin/users/UsersView.vue"
+        )
+    },
+    {
+      path: "/admin/settings",
+      name: "admin-settings",
+      component: () =>
+        import(
+          /* webpackChunkName: "admin-settings" */ "@views/admin/settings/SettingsView.vue"
+        )
+    }
   ])
 ];
 
 const generalRoutes = [
   layout("DefaultWithoutSidebar", [
-    { path: "/", name: "general-landing", component: () => import(/* webpackChunkName: "general-landing" */ "@views/general/landing/LandingView.vue") },
-    { path: "/privacy-policy", name: "general-privacy-policy", component: () => import(/* webpackChunkName: "general-privacy-policy" */ "@views/general/privacy-policy/PrivacyPolicyView.vue") },
-    { path: "/terms-and-conditions", name: "general-terms-and-conditions", component: () => import(/* webpackChunkName: "general-terms-and-conditions" */ "@views/general/terms-and-conditions/TermsAndConditionsView.vue") },
-    { path: "/user/login", meta: { isAccessableAfterLogin: false }, name: "general-user-login", component: () => import(/* webpackChunkName: "general-user-login" */ "@views/user/login/LoginView.vue") },
-    { path: "/user/login/confirm", meta: { isAccessableAfterLogin: false }, name: "general-user-login-confirm", component: () => import(/* webpackChunkName: "general-user-login-confirm" */ "@views/user/login-confirm/LoginConfirmView.vue") },
-    { path: "/user/signup", name: "general-user-signup", component: () => import(/* webpackChunkName: "general-user-signup" */ "@views/user/signup/SignupView.vue") },
-    { path: "/admin/login", name: "general-admin-login", component: () => import(/* webpackChunkName: "general-admin-login" */ "@views/admin/login/LoginView.vue") },
-    { path: "/survey/:id", name: "general-survey-fill", component: () => import(/* webpackChunkName: "general-survey-fill" */ "@views/general/survey-fill/SurveyFillView.vue") },
-    { path: "/survey/:id/submitted", name: "general-survey-submitted", component: () => import(/* webpackChunkName: "general-survey-submitted" */ "@views/general/survey-submitted/SurveySubmittedView.vue") },
-    { path: "/user/signup/thankyou", name: "general-user-signup-thankyou", component: () => import(/* webpackChunkName: "general-user-signup-thankyou" */ "@views/user/signup-thankyou/SignupThankyouView.vue") },
-    { path: "/user/delete/thankyou", name: "general-user-delete-thankyou", component: () => import(/* webpackChunkName: "general-user-delete-thankyou" */ "@views/user/delete-thankyou/DeleteThankyouView.vue") },
+    {
+      path: "/",
+      name: "general-landing",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-landing" */ "@views/general/landing/LandingView.vue"
+        )
+    },
+    {
+      path: "/privacy-policy",
+      name: "general-privacy-policy",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-privacy-policy" */ "@views/general/privacy-policy/PrivacyPolicyView.vue"
+        )
+    },
+    {
+      path: "/terms-and-conditions",
+      name: "general-terms-and-conditions",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-terms-and-conditions" */ "@views/general/terms-and-conditions/TermsAndConditionsView.vue"
+        )
+    },
+    {
+      path: "/user/login",
+      meta: { isAccessableAfterLogin: false },
+      name: "general-user-login",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-user-login" */ "@views/user/login/LoginView.vue"
+        )
+    },
+    {
+      path: "/user/login/confirm",
+      meta: { isAccessableAfterLogin: false },
+      name: "general-user-login-confirm",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-user-login-confirm" */ "@views/user/login-confirm/LoginConfirmView.vue"
+        )
+    },
+    {
+      path: "/user/signup",
+      name: "general-user-signup",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-user-signup" */ "@views/user/signup/SignupView.vue"
+        )
+    },
+    {
+      path: "/admin/login",
+      name: "general-admin-login",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-admin-login" */ "@views/admin/login/LoginView.vue"
+        )
+    },
+    {
+      path: "/survey/:id",
+      name: "general-survey-fill",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-survey-fill" */ "@views/general/survey-fill/SurveyFillView.vue"
+        )
+    },
+    {
+      path: "/survey/:id/submitted",
+      name: "general-survey-submitted",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-survey-submitted" */ "@views/general/survey-submitted/SurveySubmittedView.vue"
+        )
+    },
+    {
+      path: "/user/signup/thankyou",
+      name: "general-user-signup-thankyou",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-user-signup-thankyou" */ "@views/user/signup-thankyou/SignupThankyouView.vue"
+        )
+    },
+    {
+      path: "/user/delete/thankyou",
+      name: "general-user-delete-thankyou",
+      component: () =>
+        import(
+          /* webpackChunkName: "general-user-delete-thankyou" */ "@views/user/delete-thankyou/DeleteThankyouView.vue"
+        )
+    },
     { path: "/logout", name: "general-logout" }
   ])
 ];
-
 
 const router = new Router({
   mode: "history",
@@ -59,13 +185,12 @@ const router = new Router({
     ...adminRoutes,
     layout("DefaultWithoutSidebar", [
       { path: "/404", name: "general-404", component: PageNotFoundView },
-      { path: "*", redirect: "404" } ])
+      { path: "*", redirect: "404" }
+    ])
   ]
 });
 
-
 router.beforeEach((to, from, next) => {
-
   const hasLoggedIn = store.getters["user/hasLoggedIn"];
   const accountType = store.getters["user/accountType"];
 
@@ -74,13 +199,21 @@ router.beforeEach((to, from, next) => {
 
   const preventedWords = [ "landing", "login", "signup", "delete" ];
   const shouldBePrevented = (routeName) => {
-    return preventedWords.some((preventedWord) => routeName.includes(preventedWord));
+    return preventedWords.some((preventedWord) =>
+      routeName.includes(preventedWord)
+    );
   };
+
+  const width = window.innerWidth;
+  const isMobile = width <= 768;
 
   if (hasLoggedIn) {
     if (to.name == "general-logout") {
       store.dispatch("user/setUserData", {});
       store.dispatch("user/setToken", "");
+      store.dispatch("user/setItems", []);
+      Cookies.remove("user");
+
       return next({ name: "general-landing" });
     } else if (shouldBePrevented(to.name)) {
       if (accountType == 0) {
@@ -88,8 +221,15 @@ router.beforeEach((to, from, next) => {
       } else if (accountType == 1) {
         return next(adminMainPage);
       }
-    } else if (accountType == 0 && !to.name.startsWith("admin")) {
-      return next();
+    } else if (accountType == 0) {
+      if (!to.name.startsWith("admin")) {
+        if (to.name == "user-survey-edit") {
+          !isMobile && store.dispatch("app/setMini", true);
+        }
+        return next();
+      } else {
+        return next(userMainPage);
+      }
     } else if (accountType == 1 && !to.name.startsWith("user")) {
       return next();
     } else {
@@ -102,7 +242,6 @@ router.beforeEach((to, from, next) => {
   }
 
   return to.path.endsWith("/") ? next() : next(trailingSlash(to.path));
-
 });
 
 export default router;

--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -1,17 +1,18 @@
 import { make } from "vuex-pathify";
 
-
 const userMenuItems = [
   {
     title: "My Surveys",
     icon: "mdi-clipboard-outline",
-    to: "/user/surveys"
+    to: "/user/surveys",
+    isLastBeforeSeparation: true
   },
   {
     title: "Settings",
     icon: "mdi-cog",
     to: "/user/settings/"
-  } ];
+  }
+];
 
 const adminMenuItems = [
   {
@@ -22,7 +23,8 @@ const adminMenuItems = [
   {
     title: "Users",
     icon: "mdi-account",
-    to: "/admin/users"
+    to: "/admin/users",
+    isLastBeforeSeparation: true
   },
   {
     title: "Settings",
@@ -36,14 +38,17 @@ const generalMenuItems = [
     title: "Logout",
     icon: "mdi-logout",
     to: "/logout/"
-  } ];
+  }
+];
 
 const state = {
   userData: {
-    accountType: 0,
-    email: ""
+    accountType: null,
+    email: null,
+    hasAcceptedPrivacyPolicy: false,
+    hasAcceptedTnC: false
   },
-  token: "test",
+  token: null,
   drawer: {
     mini: false
   },
@@ -54,13 +59,19 @@ const mutations = {
   ...make.mutations(state),
   setUserData(state, data) {
     state.userData = { ...state.userData, ...data };
+  },
+  setUserDataPrivacyPolicy(state, data) {
+    state.userData.hasAcceptedPrivacyPolicy = data;
+  },
+  setUserDataTnC(state, data) {
+    state.userData.hasAcceptedTnC = data;
   }
 };
 
 const actions = {
   ...make.actions(state),
   init: async ({ dispatch }) => {
-    // access api 
+    // access api
     // put below code in then block
 
     // set user data in state
@@ -71,15 +82,26 @@ const actions = {
     // 1 = admin
     dispatch("checkAccountTypeAndSetMenuItems");
   },
-  checkAccountTypeAndSetMenuItems: ({ dispatch }) => {
+  checkAccountTypeAndSetMenuItems: ({ state, dispatch }) => {
     if (state.userData.accountType == 0) {
       dispatch("setItems", userMenuItems.concat(generalMenuItems));
     } else if (state.userData.accountType == 1) {
       dispatch("setItems", adminMenuItems.concat(generalMenuItems));
     }
+  },
+  setUserDataPrivacyPolicy: ({ state, dispatch }, data) => {
+    dispatch("setUserData", {
+      ...state.userData,
+      ...{ hasAcceptedPrivacyPolicy: data }
+    });
+  },
+  setUserDataTnC: ({ state, dispatch }, data) => {
+    dispatch("setUserData", {
+      ...state.userData,
+      ...{ hasAcceptedTnC: data }
+    });
   }
 };
-
 
 const getters = {
   hasLoggedIn: (state) => {

--- a/ui/src/styles/components/_buttons.scss
+++ b/ui/src/styles/components/_buttons.scss
@@ -4,8 +4,11 @@
   }
 
   &.v-btn--default {
-    background-color: $white;
-    color: transparentize($black, .6);
+    background-color: $white !important;
+    color: transparentize($black, 0.6);
+    font-weight: 400;
+    text-transform: unset;
+    border: 1px solid $light-gray;
+    border-radius: 0;
   }
-
 }

--- a/ui/src/styles/components/_typography.scss
+++ b/ui/src/styles/components/_typography.scss
@@ -1,0 +1,7 @@
+.text-primary {
+  color: $primary-text-color !important;
+}
+
+.text-secondary {
+  color: $secondary-text-color !important; 
+}

--- a/ui/src/styles/components/index.scss
+++ b/ui/src/styles/components/index.scss
@@ -1,1 +1,2 @@
 @import "./_buttons.scss";
+@import "./_typography.scss";

--- a/ui/src/styles/mixins/_buttons.scss
+++ b/ui/src/styles/mixins/_buttons.scss
@@ -1,5 +1,4 @@
-@each $btn-font-size,
-$value in $btn-font-sizes {
+@each $btn-font-size, $value in $btn-font-sizes {
   .v-btn {
     font-family: $font-family-sans-serif;
 
@@ -9,14 +8,12 @@ $value in $btn-font-sizes {
   }
 }
 
-@each $theme-color,
-$value in $theme-colors {
+@each $theme-color, $value in $theme-colors {
   .v-btn {
     &.v-btn--#{$theme-color} {
-      background-color: $value  !important;
+      background-color: $value !important;
       color: $white;
       text-transform: uppercase;
     }
-
   }
 }

--- a/ui/src/styles/variables/_colors.scss
+++ b/ui/src/styles/variables/_colors.scss
@@ -1,20 +1,23 @@
 // Colors
 $material-light: (
-  'background': #EEEEEE,
-  'text': ('primary': #333333,
-    'secondary': #999999)
+  "background": #eeeeee,
+  "text": (
+    "primary": #333333,
+    "secondary": #999999,
+  ),
 );
 
 $primary-color: #6200ee !default;
-$accent-color: #EE7200 !default;
-$dark-primary-color: #5200C7;
-$dark-primary-color-2: #4A01B2;
-$disabled-color: #D8D8D8;
+$accent-color: #ee7200 !default;
+$dark-primary-color: #5200c7;
+$dark-primary-color-2: #4a01b2;
+$disabled-color: #d8d8d8;
 
 $white: #fff;
-$grayish-white: #FAFAFA;
-$light-gray: #DFE0EB;
-$gray: #D8D8D8;
+$grayish-white: #fafafa;
+$light-gray: #dfe0eb;
+$light-blue: #f7f9fd;
+$gray: #d8d8d8;
 $black: #000;
 $dark-gray: #6c757d;
 
@@ -25,12 +28,11 @@ $theme-colors: (
   "accent": $accent-color,
 );
 
-$primary-text-color: #000; 
-$secondary-text-color: transparentize($primary-text-color, .4); 
-
+$primary-text-color: #000;
+$secondary-text-color: transparentize($primary-text-color, 0.4);
 
 $overlays: (
-  "primary": linear-gradient(0deg, rgba(187, 134, 252, 0.12), rgba(187, 134, 252, 0.12)),
-  "success": #E1FCEF,
-  "info": #F0F1FA,
+  "primary": #bb86fc1f,
+  "success": #e1fcef,
+  "info": #f0f1fa,
 );

--- a/ui/src/util/dates.js
+++ b/ui/src/util/dates.js
@@ -1,0 +1,5 @@
+import moment from "moment";
+
+export const convertToStandardDate = function (value) {
+  return moment(value, "DD/MM/YYYY hh:mm:ss").format("DD MMM YYYY");
+};

--- a/ui/src/views/admin/login/LoginView.vue
+++ b/ui/src/views/admin/login/LoginView.vue
@@ -31,8 +31,7 @@
                       rules="required|email"
                     >
                       <v-text-field
-                        v-model="formData.email"
-                        :rules="[() => !!formData.email || 'This field is required']"
+                        v-model.trim="formData.email"
                         placeholder="email@email.com"
                         outlined
                         required
@@ -46,10 +45,10 @@
                     <ValidationProvider
                       v-slot="{ errors }"
                       name="Password"
-                      rules="required|alpha|min:8"
+                      rules="required|min:8"
                     >
                       <v-text-field
-                        v-model="formData.password"
+                        v-model.trim="formData.password"
                         outlined
                         hint="Minimum 8 characters"
                         persistent-hint

--- a/ui/src/views/admin/login/LoginView.vue
+++ b/ui/src/views/admin/login/LoginView.vue
@@ -1,20 +1,175 @@
 <template>
   <v-container
-    id="login-view"
-    class="fill-height text-center"
+    class="login-view fill-height"
     tag="section"
   >
     <v-row justify="center">
-      <v-col cols="auto">
-        admin login view
+      <v-col :cols="isMobile? 12 : 8">
+        <v-card
+          class="login-view__card"
+          :elevation="isMobile? 0 : 2"
+        >
+          <v-card-title class="login-view__title">
+            Log In
+          </v-card-title>
+          <ValidationObserver v-slot="{ handleSubmit }">
+            <v-form
+              v-model="isFormValid"
+              class="login-form"
+              @keyup.native.enter="handleSubmit(onFormSubmit)"
+              @submit.prevent="handleSubmit(onFormSubmit)"
+            >
+              <v-container>
+                <v-row class="login-view__row">
+                  <v-col
+                    cols="12"
+                    class="pb-0"
+                  >
+                    <ValidationProvider
+                      v-slot="{ errors }"
+                      name="E-mail"
+                      rules="required|email"
+                    >
+                      <v-text-field
+                        v-model="formData.email"
+                        :rules="[() => !!formData.email || 'This field is required']"
+                        placeholder="email@email.com"
+                        outlined
+                        required
+                        :error-messages="errors[0]"
+                        label="E-mail"
+                      />
+                    </ValidationProvider>
+                  </v-col>
+
+                  <v-col cols="12">
+                    <ValidationProvider
+                      v-slot="{ errors }"
+                      name="Password"
+                      rules="required|alpha|min:8"
+                    >
+                      <v-text-field
+                        v-model="formData.password"
+                        outlined
+                        hint="Minimum 8 characters"
+                        persistent-hint
+                        label="Password"
+                        :append-icon="isPasswordShown ? 'mdi-eye' : 'mdi-eye-off'"
+                        :type="isPasswordShown ? 'text' : 'password'"
+                        :error-messages="errors[0]"
+                        @click:append="isPasswordShown = !isPasswordShown"
+                      />
+                    </ValidationProvider>
+                  </v-col>
+                  <v-col cols="12">
+                    <v-btn
+                      class="v-btn--is-elevated v-btn--primary"
+                      height="53"
+                      block
+                      @click="handleSubmit(onFormSubmit)"
+                    >
+                      LOG IN
+                    </v-btn>
+                  </v-col>
+                </v-row>
+              </v-container>
+            </v-form>
+          </ValidationObserver>
+        </v-card>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script>
-export default { name: "LoginView" };
+export default {
+  name: "LoginView",
+  data() {
+    return {
+      isFormValid: false,
+      isPasswordShown: false,
+      formData: {
+        email: "",
+        password: ""
+      }
+    };
+  },
+  methods: {
+    onFormSubmit() {
+      // get submission with this.formData
+      // submit form
+      // get auth key
+      // save to vuex
+      const userData = {
+        accountType: 1,
+        email: "admin@email.com"
+      };
+      this.$store.dispatch("user/setToken", "test");
+      this.$store.dispatch("user/setUserData", userData);
+      this.$store.dispatch("user/checkAccountTypeAndSetMenuItems");
+
+      this.$router.push({ name: "admin-surveys" });
+    }
+  }
+};
 </script>
 
 <style lang="scss">
+.login-view {
+  @include default-container-padding;
+
+  @media only screen and (max-width: map-get($breakpoints, "md")) {
+    padding: 0;
+  }
+
+  &__card {
+    padding: calculate-space(6);
+    border-radius: 10px;
+
+    @media only screen and (max-width: map-get($breakpoints, "md")) {
+      padding: calculate-space(6) calculate-space(1.5) calculate-space(6);
+    }
+  }
+
+  &__row {
+    > .col {
+      &:not:first-of-type {
+        &:not:last-of-type {
+          padding-bottom: 0;
+        }
+      }
+    }
+  }
+
+  &__title {
+    @include font-size(2);
+  }
+
+  &__description {
+    @include font-size(1);
+
+    a {
+      color: inherit !important;
+    }
+  }
+
+  .login-form {
+    &__or {
+      display: block;
+      text-align: center;
+      margin: calculate-space(2) calculate-space(2);
+    }
+
+    &__google-button {
+      text-transform: none;
+      background-color: $white;
+      border: 1px solid $light-gray;
+      font-weight: 400;
+
+      .logo {
+        margin-left: 10px;
+      }
+    }
+  }
+}
 </style>

--- a/ui/src/views/general/landing/LandingView.vue
+++ b/ui/src/views/general/landing/LandingView.vue
@@ -57,8 +57,8 @@ export default {
   computed: {
     mainPicture() {
       return require("@assets/svg/home.svg");
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/ui/src/views/user/login-confirm/LoginConfirmView.vue
+++ b/ui/src/views/user/login-confirm/LoginConfirmView.vue
@@ -12,8 +12,7 @@
           :image="require('@assets/svg/man-woman-holding-mail.svg')"
           :max-image-height="isMobile ? 145: 305"
           :max-image-width="isMobile? 200: 400"
-        >
-        </content-card>
+        />
       </v-col>
     </v-row>
   </v-container>

--- a/ui/src/views/user/login/LoginView.vue
+++ b/ui/src/views/user/login/LoginView.vue
@@ -22,19 +22,20 @@
               v-model="isFormValid"
               class="login-form"
               @keyup.native.enter="handleSubmit(onFormSubmit)"
-              @submit.prevent="handleSubmit(onFormSubmit)"
             >
               <v-container>
-                <v-row>
-                  <v-col cols="12">
+                <v-row class="login-view__row">
+                  <v-col
+                    cols="12"
+                    class="pb-0"
+                  >
                     <ValidationProvider
                       v-slot="{ errors }"
                       name="E-mail"
                       rules="required|email"
                     >
                       <v-text-field
-                        v-model="formData.email"
-                        :rules="[() => !!formData.email || 'This field is required']"
+                        v-model.trim="formData.email"
                         placeholder="email@email.com"
                         outlined
                         required
@@ -48,10 +49,10 @@
                     <ValidationProvider
                       v-slot="{ errors }"
                       name="Password"
-                      rules="required|alpha|min:8"
+                      rules="required|min:8"
                     >
                       <v-text-field
-                        v-model="formData.password"
+                        v-model.trim="formData.password"
                         outlined
                         hint="Minimum 8 characters"
                         persistent-hint
@@ -107,8 +108,8 @@ export default {
       isPasswordShown: false,
       formData: {
         email: "",
-        password: "",
-      },
+        password: ""
+      }
     };
   },
   methods: {
@@ -119,15 +120,17 @@ export default {
       // save to vuex
       const userData = {
         accountType: 0,
-        email: "",
+        email: "user@email.com",
+        hasAcceptedPrivacyPolicy: false,
+        hasAcceptedTnC: false
       };
       this.$store.dispatch("user/setToken", "test");
       this.$store.dispatch("user/setUserData", userData);
       this.$store.dispatch("user/checkAccountTypeAndSetMenuItems");
 
       this.$router.push({ name: "user-surveys" });
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/ui/src/views/user/settings/SettingsView.vue
+++ b/ui/src/views/user/settings/SettingsView.vue
@@ -1,13 +1,12 @@
 <template>
   <v-container
     id="user-settings-view"
-    fluid
     tag="section"
   >
     <v-row justify="center">
       <v-col
-        cols="8"
-        md="8"
+        cols="10"
+        md="10"
       >
         <material-card
           color="primary"

--- a/ui/src/views/user/signup-thankyou/SignupThankyouView.vue
+++ b/ui/src/views/user/signup-thankyou/SignupThankyouView.vue
@@ -10,10 +10,12 @@
           title="Thanks for registering!" 
           description="Please check your inbox or spams  to confirm your registration" 
           :image="require('@assets/svg/man-woman-holding-mail.svg')"
-          >
-          <template v-slot:actions>
+        >
+          <template #actions>
             Haven't received your email? 
-            <v-btn text>Click here</v-btn>
+            <v-btn text>
+              Click here
+            </v-btn>
           </template>
         </content-card>
       </v-col>

--- a/ui/src/views/user/surveys/ConditionsInteraction.vue
+++ b/ui/src/views/user/surveys/ConditionsInteraction.vue
@@ -1,0 +1,94 @@
+<template>
+  <v-container
+    class="conditions-interaction"
+    tag="section"
+    fluid
+  >
+    <v-row justify="center">
+      <v-col
+        cols="12"
+        class="pa-0"
+      >
+        <div class="pa-4 text-left">
+          <h1 class="text-capitalize">
+            {{ title }}
+          </h1>
+          <p class="mt-3">
+            Please read this software {{ title }} carefully before using the software.
+          </p>
+        </div>
+        <div class="conditions-interaction__content text-secondary text-left">
+          <p>
+            {{ content || 'No content were given.' }}
+          </p>
+        </div>
+        <p class="pa-4 text-left">
+          By accepting the terms and using this software, you are agreeing to be bound by the
+          <a :href="link">
+            {{ title }}
+          </a>.
+        </p>
+      </v-col>
+    </v-row>
+    <v-row justify="space-between">
+      <v-col cols="5">
+        <v-btn
+          block
+          height="53"
+          class="v-btn--default"
+          @click="confirmConditions(false)"
+        >
+          DECLINE
+        </v-btn>
+      </v-col>
+      <v-col cols="5">
+        <v-btn
+          block
+          height="53"
+          class="v-btn--primary"
+          @click="confirmConditions(true)"
+        >
+          ACCEPT
+        </v-btn>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+<script>
+export default {
+  name: "ConditionsInteraction",
+  props: {
+    title: {
+      type: String,
+      default: ""
+    },
+    link: {
+      type: String,
+      default: ""
+    },
+    content: {
+      type: String,
+      default: ""
+    }
+  },
+  methods: {
+    confirmConditions(isConfirmed) {
+      this.$emit("confirm", isConfirmed);
+    }
+  }
+};
+</script>
+<style lang="scss" scoped>
+.conditions-interaction {
+  @include font-size(1);
+
+  &__content {
+    max-height: 200px;
+    padding: 20px 16px;
+    overflow-y: scroll;
+    border-top: 2px solid $light-gray;
+    border-bottom: 2px solid $light-gray;
+    margin-bottom: 8px;
+  }
+}
+</style>

--- a/ui/src/views/user/surveys/SurveysView.vue
+++ b/ui/src/views/user/surveys/SurveysView.vue
@@ -232,7 +232,7 @@
                           </v-col> -->
                           <v-col cols="auto">
                             <v-text-field
-                              v-model="keyword"
+                              v-model.trim="keyword"
                               solo
                               dense
                               class="user-surveys-search --is-desktop"

--- a/ui/src/views/user/surveys/SurveysView.vue
+++ b/ui/src/views/user/surveys/SurveysView.vue
@@ -19,7 +19,6 @@
                   <conditions-interaction
                     title="Privacy Policy"
                     link="http://www.google.com"
-                    :is-close-button-shown="true"
                     :content="privacyPolicyContent"
                     @confirm="onConfirmPrivacyPolicy"
                   />
@@ -28,7 +27,6 @@
                   <conditions-interaction
                     title="Terms and Conditions"
                     link="http://www.google.com"
-                    :is-close-button-shown="true"
                     :content="tnCContent"
                     @confirm="onConfirmTnC"
                   />
@@ -113,7 +111,7 @@
                           CREATE SURVEY
                         </v-btn>
                       </v-col>
-                      <v-col cols="10">
+                      <v-col cols="9">
                         <v-text-field
                           v-model.trim="keyword"
                           solo
@@ -127,7 +125,7 @@
                           {{ surveys.length }} surveys
                         </p>
                       </v-col>
-                      <v-col cols="2">
+                      <v-col cols="3" class="text-right">
                         <v-btn
                           text
                           icon
@@ -148,6 +146,7 @@
                         v-for="survey in filteredSurveys"
                         :key="survey.id"
                         cols="12"
+                        class="pa-0"
                         @click="onClickSurveyListItem(survey)"
                       >
                         <v-list-item-content class="pa-2 pb-4">
@@ -348,7 +347,7 @@ export default {
     ConditionsInteraction: () =>
       import(
         /* webpackChunkName: "conditions-interaction" */
-        "./ConditionsInteraction"
+        "./components/ConditionsInteraction"
       ),
   },
   data() {

--- a/ui/src/views/user/surveys/components/ConditionsInteraction.vue
+++ b/ui/src/views/user/surveys/components/ConditionsInteraction.vue
@@ -25,13 +25,13 @@
         <p class="pa-4 text-left">
           By accepting the terms and using this software, you are agreeing to be bound by the
           <a :href="link">
-            {{ title }}
-          </a>.
+            {{ title }}.
+          </a>
         </p>
       </v-col>
     </v-row>
     <v-row justify="space-between">
-      <v-col cols="5">
+      <v-col cols="6" class="pa-4">
         <v-btn
           block
           height="53"
@@ -41,7 +41,7 @@
           DECLINE
         </v-btn>
       </v-col>
-      <v-col cols="5">
+      <v-col cols="6" class="pa-4">
         <v-btn
           block
           height="53"


### PR DESCRIPTION
What's changed: 
- ui/.eslintrc.js: added new rules
- ui/src/layouts/default/Drawer.vue: fixed some sidebar bugs
- ui/src/layouts/default/AppBar.vue: fixed the style to match the design
- ui/src/layouts/default/List.vue: fixed the style to match the design
- ui/src/layouts/default/widgets/DrawerHeader.vue: loaded user email to the view, styling
- ui/src/layouts/default/widgets/DrawerToggle.vue: fixed the style to match the design
- ui/src/views/user/surveys/SurveysView.vue: finished hasAcceptedTnC and hasAcceptedPrivacyPolicy handling; loaded datatable, loaded the list
- ui/src/views/admin/login/LoginView.vue: finished the admin login view (only copied the user login view with some adjustments)
- ui/src/router/index.js: handled some additional cases on certain pages (ex: minified the sidebar when visiting user-survey-edit page) 
- ui/src/store/modules/user.js: saved privacy policy and tnc confirmation in vuex
- ui/src/styles/components/index.scss: loaded _typography.scss
- ui/src/styles/variables/_colors.scss: added new colors, converted some colors to HEX values (not RGBA)
- ui/src/views/user/login/LoginView.vue: removed alpha rule, added trim so that spaces wont be counted as text

What's new:
- ui/src/components/BottomSheet.vue: bottom sheet component (like modal, but slides from bottom). Not used yet, will be used later
- ui/src/components/Modal.vue: new modal (dialog) component. Currently used in user/surveys page
- ui/src/assets/json/lorem-ipsum.json: new lorem ipsum placeholder text. Should be removed later if the actual TnC and PP are given
- ui/src/filters/index.js: new Vue filters (capitalize, standardDate) for cleaner code. 
- ui/src/views/user/surveys/ConditionsInteraction.vue: serves TnC and PrivacyPolicy to the user as well as provides some interactions.
- ui/src/styles/components/_typography.scss: added some overrides related to text  (text-primary, text-secondary)
- ui/src/util/dates.js : new date helpers

The rest of changes are caused by `yarn lint --fix`

To be done: 
- survey builder page
- refactor SurveysView file; right now the lines exceed 500 and the if rules are hard to read 
- script to lint on commit 
- refactor modal component
- generalize datatable styling so that it can be used in other pages 
- the placeholder image in my surveys page has white bg; its not very visible but better to be removed


Notable: 
- current datatable design doesnt match the original design. The original design inludes some features that are not actually needed (ex: checkbox, filter button), and the row styling is a bit different. I will go back to it after finishing the survey builder page

---

Screenshots: 
admin login: 
mobile: 
![image](https://user-images.githubusercontent.com/12537724/172018021-3a1e1f53-5122-47f6-b441-54bdccbdc944.png)

desktop: 
![image](https://user-images.githubusercontent.com/12537724/172018042-b28064a4-ab57-4888-8bf5-0c8cc49cc7e4.png)

--

before accepting privacy policy & tnc: 
mobile: 
![image](https://user-images.githubusercontent.com/12537724/172017890-dbf3c2f1-49d2-485d-ba58-8db65f762bdf.png)
![image](https://user-images.githubusercontent.com/12537724/172017937-7e455497-657e-4996-910b-fb302b1df69d.png)

desktop: 
![image](https://user-images.githubusercontent.com/12537724/172018057-2c5c0c41-4783-4d4c-9cbe-9bd905538a9e.png)

--

on viewing privacy  policy & tnc: 
mobile: 
![image](https://user-images.githubusercontent.com/12537724/172017944-0f6805a5-d436-4be3-9a1d-c2443da5d2ee.png)

desktop:
![image](https://user-images.githubusercontent.com/12537724/172018060-bd13459a-2ae3-49b2-9d82-2c3430dcc6e2.png)

--

surveys: 
mobile: 
![image](https://user-images.githubusercontent.com/12537724/172017954-872b55d1-ef30-4a8e-8816-433223f4893f.png)
![image](https://user-images.githubusercontent.com/12537724/172017961-5ec524ec-ce5e-44f7-a2ff-76a09b07bf55.png)
sorted: 
![image](https://user-images.githubusercontent.com/12537724/172017966-7ee918ae-b514-4531-8d54-b60d5f1ae68b.png)

desktop: 
![image](https://user-images.githubusercontent.com/12537724/172018071-ffd49d88-1f89-4162-a555-8de802cd59c8.png)
![image](https://user-images.githubusercontent.com/12537724/172018085-79f79590-65bf-4a51-8af6-03d08ee71ab1.png)
![image](https://user-images.githubusercontent.com/12537724/172018095-af6102cb-33e7-4c2e-bb0d-d4f45395f4c7.png)

