### PR TITLE
fix: prevent error on docker-compose build by removing unused GenerateForm element

### DIFF
--- a/ui/src/form-builder/components/FormBuilder.vue
+++ b/ui/src/form-builder/components/FormBuilder.vue
@@ -107,15 +107,13 @@
 <script>
 import WidgetConfig from "./WidgetConfig";
 import WidgetForm from "./WidgetForm";
-import GenerateForm from "./GenerateForm";
 import { EventBus } from "@/util/event-bus";
 
 export default {
   name: "FormBuilder",
   components: {
     WidgetConfig,
-    WidgetForm,
-    GenerateForm
+    WidgetForm
   },
   props: {
     value: {


### PR DESCRIPTION
What's changed:
- ui/src/form-builder/components/FormBuilder.vue : removed GenerateForm because it is unused and may cause error on `docker-compose build`