### PR TITLE
feat: implement API request for user-signup

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,17 +1,6 @@
 server {
     listen 8000;
     location / {
-		add_header Access-Control-Allow-Origin $http_origin always;
-		if ($request_method = 'OPTIONS') {
-			add_header 'Access-Control-Allow-Origin' "$http_origin" always;
-			add_header 'Access-Control-Allow-Credentials' 'true' always;
-			add_header 'Access-Control-Allow-Headers' "Origin, X-Requested-With, Content-Type, Accept" always;
-			add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
-			add_header 'Access-Control-Max-Age' 1728000;
-			add_header 'Content-Type' 'text/plain; charset=utf-8';
-			add_header 'Content-Length' 0;
-			return 204;
-		}
         include uwsgi_params;
         uwsgi_pass api:9000;
     }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,17 @@
 server {
     listen 8000;
     location / {
+		add_header Access-Control-Allow-Origin $http_origin always;
+		if ($request_method = 'OPTIONS') {
+			add_header 'Access-Control-Allow-Origin' "$http_origin" always;
+			add_header 'Access-Control-Allow-Credentials' 'true' always;
+			add_header 'Access-Control-Allow-Headers' "Origin, X-Requested-With, Content-Type, Accept" always;
+			add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+			add_header 'Access-Control-Max-Age' 1728000;
+			add_header 'Content-Type' 'text/plain; charset=utf-8';
+			add_header 'Content-Length' 0;
+			return 204;
+		}
         include uwsgi_params;
         uwsgi_pass api:9000;
     }

--- a/ui/.env.development
+++ b/ui/.env.development
@@ -1,2 +1,2 @@
 NODE_ENV="development"
-VUE_APP_API_BASE_URL="localhost:8000/"
+VUE_APP_API_BASE_URL="http://localhost:8000/api"

--- a/ui/.env.development
+++ b/ui/.env.development
@@ -1,2 +1,2 @@
 NODE_ENV="development"
-VUE_APP_API_BASE_URL="http://localhost:8000/api"
+VUE_APP_API_BASE_URL="http://localhost:8000/api/"

--- a/ui/.env.production
+++ b/ui/.env.production
@@ -1,2 +1,2 @@
 NODE_ENV="production"
-VUE_APP_API_BASE_URL="http://localhost:8000/api"
+VUE_APP_API_BASE_URL="http://localhost:8000/api/"

--- a/ui/.env.production
+++ b/ui/.env.production
@@ -1,2 +1,2 @@
 NODE_ENV="production"
-VUE_APP_API_BASE_URL="localhost:8000/"
+VUE_APP_API_BASE_URL="http://localhost:8000/api"

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -31,8 +31,8 @@ axios.interceptors.response.use(
   }
 );
 
-const GET_SURVEYS_URL = "/user/surveys";
-const ADD_SURVEY_URL = "/user/surveys";
+const GET_SURVEYS_URL = "user/surveys";
+const ADD_SURVEY_URL = "user/surveys";
 
 export const getSurveys = () => {
   return axios.get(GET_SURVEYS_URL);
@@ -42,8 +42,14 @@ export const addSurvey = (data) => {
   return axios.post(ADD_SURVEY_URL, data);
 };
 
-const USER_SIGNUP_URL = "/authentication/signup";
+const USER_SIGNUP_URL = "authentication/signup";
 
 export const userSignup = (data) => {
   return axios.post(USER_SIGNUP_URL, data);
+}
+
+const USER_LOGIN_URL = "authentication/login";
+
+export const userLogin = (data) => {
+  return axios.post(USER_LOGIN_URL, data, config);
 }

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -38,3 +38,9 @@ export const getSurveys = () => {
 export const addSurvey = (data) => {
   return axios.post(ADD_SURVEY_URL, data);
 };
+
+const USER_SIGNUP_URL = "/authentication/signup";
+
+export const userSignup = (data) => {
+  return axios.post(USER_SIGNUP_URL, data);
+}

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -43,16 +43,13 @@ const USER_SIGNUP_URL = "/authentication/signup";
 
 export const userSignup = (data) => {
   //return axios.post(USER_SIGNUP_URL, data);
+  //please make data in json format and then stringify it before feeding the data into this function
   return axios.post(USER_SIGNUP_URL, {
-    body: {
-      mode: "raw",
-      raw: "{\n    \"email\": \"" + data.email + "\",\n    \"password\": \"" + data.password + "\"\n}",
-      options: {
-        raw: {
-          language: "json"
-        }
-      }
-    }
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: data
   });
 }
 

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -42,43 +42,12 @@ export const addSurvey = (data) => {
 const USER_SIGNUP_URL = "/authentication/signup";
 
 export const userSignup = (data) => {
-  //return axios.post(USER_SIGNUP_URL, data);
-  //please make data in json format and then stringify it before feeding the data into this function
-  return axios.post(USER_SIGNUP_URL, {
+  let config = {
     headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    },
-    body: data
-  });
-}
-
-/*
-export const userSignup = (data) => {
-  return axios({
-    method: "post",
-    header: [],
-    body: {
-      mode: "raw",
-      raw: "{\n    \"email\": \"" + data.email + "\",\n    \"password\": \"" + data.password + "\"\n}",
-      options: {
-        raw: {
-          language: "json"
-        }
-      }
-    },
-    url: {
-      raw: baseURL + USER_SIGNUP_URL,
-      host: [
-        "localhost"
-      ],
-      port: "8000",
-      path: [
-        "api",
-        "authentication",
-        "signup"
-      ]
+      "Accept": "application/json",
+      "Content-Type": "application/json"
     }
-  });
+  }
+
+  return axios.post(USER_SIGNUP_URL, data, config);
 }
-*/

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -42,5 +42,46 @@ export const addSurvey = (data) => {
 const USER_SIGNUP_URL = "/authentication/signup";
 
 export const userSignup = (data) => {
-  return axios.post(USER_SIGNUP_URL, data);
+  //return axios.post(USER_SIGNUP_URL, data);
+  return axios.post(USER_SIGNUP_URL, {
+    body: {
+      mode: "raw",
+      raw: "{\n    \"email\": \"" + data.email + "\",\n    \"password\": \"" + data.password + "\"\n}",
+      options: {
+        raw: {
+          language: "json"
+        }
+      }
+    }
+  });
 }
+
+/*
+export const userSignup = (data) => {
+  return axios({
+    method: "post",
+    header: [],
+    body: {
+      mode: "raw",
+      raw: "{\n    \"email\": \"" + data.email + "\",\n    \"password\": \"" + data.password + "\"\n}",
+      options: {
+        raw: {
+          language: "json"
+        }
+      }
+    },
+    url: {
+      raw: baseURL + USER_SIGNUP_URL,
+      host: [
+        "localhost"
+      ],
+      port: "8000",
+      path: [
+        "api",
+        "authentication",
+        "signup"
+      ]
+    }
+  });
+}
+*/

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -6,6 +6,9 @@ const { timeout, baseURL } = config;
 axios.defaults.baseURL = baseURL;
 axios.defaults.timeout = timeout;
 
+axios.defaults.headers.common["Accept"] = "application/json";
+axios.defaults.headers.common["Content-Type"] = "application/json";
+
 // handle default
 axios.interceptors.request.use(
   (config) => {
@@ -42,12 +45,5 @@ export const addSurvey = (data) => {
 const USER_SIGNUP_URL = "/authentication/signup";
 
 export const userSignup = (data) => {
-  let config = {
-    headers: {
-      "Accept": "application/json",
-      "Content-Type": "application/json"
-    }
-  }
-
-  return axios.post(USER_SIGNUP_URL, data, config);
+  return axios.post(USER_SIGNUP_URL, data);
 }

--- a/ui/src/views/user/signup/SignupView.vue
+++ b/ui/src/views/user/signup/SignupView.vue
@@ -129,28 +129,6 @@ export default {
           this.$notify.toast("Something went wrong. Please try again later.");
           console.log(error);
         });
-
-      /* WORKING CODE WITH FETCH
-      console.log("Will try to fetch now....");
-      fetch("http://localhost:8000/api/authentication/signup", {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({email: this.formData.email, password: this.formData.password})
-      }).then((data) => {
-          console.log("We get response!");
-          console.log(data);
-          this.$router
-            .push({ name: "general-user-signup-thankyou" })
-            .catch(() => {});
-        })
-        .catch((error) => {~
-          console.log("Aw, error!");
-          console.log(error);
-        });
-      */
     }
   }
 };

--- a/ui/src/views/user/signup/SignupView.vue
+++ b/ui/src/views/user/signup/SignupView.vue
@@ -98,6 +98,8 @@
 </template>
 
 <script>
+import { userSignup } from "@api";
+
 export default {
   name: "SignupView",
   data() {
@@ -112,8 +114,19 @@ export default {
   },
   methods: {
     onFormSubmit() {
-      // to do: post form data to back-end's registration api
-      this.$router.push({ name: "general-user-signup-thankyou" });
+      // post form data to back-end's registration api
+      userSignup(this.formData)
+        .then((response) => {
+          console.log(response);
+          // do something with the response
+          console.log('registration should be successful?');
+          this.$router
+            .push({ name: "general-user-signup-thankyou" })
+            .catch(() => {});
+        })
+        .catch((error) => {
+          console.log(error);
+        });
     }
   }
 };

--- a/ui/src/views/user/signup/SignupView.vue
+++ b/ui/src/views/user/signup/SignupView.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script>
-import { userSignup } from "@api";
+//import { userSignup } from "@api";
 
 export default {
   name: "SignupView",
@@ -115,11 +115,12 @@ export default {
   methods: {
     onFormSubmit() {
       // post form data to back-end's registration api
+      /*
       userSignup(this.formData)
         .then((response) => {
           console.log(response);
           // do something with the response
-          console.log('registration should be successful?');
+          console.log("registration should be successful?");
           this.$router
             .push({ name: "general-user-signup-thankyou" })
             .catch(() => {});
@@ -127,6 +128,35 @@ export default {
         .catch((error) => {
           console.log(error);
         });
+      */
+     fetch("http://localhost:8000/api/authentication/signup", {
+        method: "POST",
+        headers: [],
+        body: {
+          mode: "raw",
+          raw: "{\n    \"email\": \"" + this.formData.email + "\",\n    \"password\": \"" + this.formData.password + "\"\n}",
+          options: {
+            raw: {
+              language: "json"
+            }
+          }
+        }
+      }).then((data) => {
+          console.log(data);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+      /*
+      fetch("http://localhost:8000/api/authentication/signup")
+        .then((response) => response.json())
+        .then((data) => {
+          console.log(data);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+      */
     }
   }
 };

--- a/ui/src/views/user/signup/SignupView.vue
+++ b/ui/src/views/user/signup/SignupView.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script>
-//import { userSignup } from "@api";
+import { userSignup } from "@api";
 
 export default {
   name: "SignupView",
@@ -115,45 +115,42 @@ export default {
   methods: {
     onFormSubmit() {
       // post form data to back-end's registration api
-      /*
-      userSignup(this.formData)
+      console.log("Will try to fetch now....");
+      console.log(this.formData.email);
+      console.log(this.formData.password);
+      userSignup(JSON.stringify(this.formData))
         .then((response) => {
+          console.log("We get response!");
           console.log(response);
-          // do something with the response
-          console.log("registration should be successful?");
           this.$router
             .push({ name: "general-user-signup-thankyou" })
             .catch(() => {});
         })
         .catch((error) => {
+          console.log("Aw, error!");
           console.log(error);
         });
-      */
-     fetch("http://localhost:8000/api/authentication/signup", {
-        method: "POST",
-        headers: [],
-        body: {
-          mode: "raw",
-          raw: "{\n    \"email\": \"" + this.formData.email + "\",\n    \"password\": \"" + this.formData.password + "\"\n}",
-          options: {
-            raw: {
-              language: "json"
-            }
-          }
-        }
+
+      /* WORKING CODE
+      console.log("Will try to fetch now....");
+      console.log(this.formData.email);
+      console.log(this.formData.password);
+      fetch("http://localhost:8000/api/authentication/signup", {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({email: this.formData.email, password: this.formData.password})
       }).then((data) => {
+          console.log("We get response!");
           console.log(data);
+          this.$router
+            .push({ name: "general-user-signup-thankyou" })
+            .catch(() => {});
         })
-        .catch((error) => {
-          console.log(error);
-        });
-      /*
-      fetch("http://localhost:8000/api/authentication/signup")
-        .then((response) => response.json())
-        .then((data) => {
-          console.log(data);
-        })
-        .catch((error) => {
+        .catch((error) => {~
+          console.log("Aw, error!");
           console.log(error);
         });
       */

--- a/ui/src/views/user/signup/SignupView.vue
+++ b/ui/src/views/user/signup/SignupView.vue
@@ -114,27 +114,24 @@ export default {
   },
   methods: {
     onFormSubmit() {
-      // post form data to back-end's registration api
-      console.log("Will try to fetch now....");
-      console.log(this.formData.email);
-      console.log(this.formData.password);
-      userSignup(JSON.stringify(this.formData))
+      userSignup(this.formData)
         .then((response) => {
-          console.log("We get response!");
-          console.log(response);
-          this.$router
-            .push({ name: "general-user-signup-thankyou" })
-            .catch(() => {});
+          if (response["message"].includes(" already exists.")) {
+            this.$notify.toast(response["message"]);
+          }
+          else {
+            this.$router
+              .push({ name: "general-user-signup-thankyou" })
+              .catch(() => {});
+          }
         })
         .catch((error) => {
-          console.log("Aw, error!");
+          this.$notify.toast("Something went wrong. Please try again later.");
           console.log(error);
         });
 
-      /* WORKING CODE
+      /* WORKING CODE WITH FETCH
       console.log("Will try to fetch now....");
-      console.log(this.formData.email);
-      console.log(this.formData.password);
       fetch("http://localhost:8000/api/authentication/signup", {
         method: 'POST',
         headers: {


### PR DESCRIPTION
What's changed:
- ui/.env.development : changed vue's api base url to "http://localhost:8000/api" for now.
- ui/.env.production : changed vue's api base url to "http://localhost:8000/api" for now.
- ui/src/api/index.js : implemented API request function userSignup() using axios.
- ui/src/views/user/signup/SignupView.vue : now calls API's userSignup() on form submit, added handler upon "user already exists" and upon error.

Notable:
- It seems to be important to run the docker services in separate terminals/cmds. In my case, I need to have a separate terminal for each of `docker-compose up db`, `docker-compose up phpmyadmin`, `docker-compose up api`, `docker-compose up ui` and `docker-compose up nginx`. I can't 100% confirm but apparently running only one terminal with `docker-compose up` for all services is causing CORS issue with axios (but not with traditional fetch).
- There is no 'elegant' way to distinguish between "user was created successfully" and "user already exists", because both cases return success code 200 with no 'status' field. There is only 'message' field in the response. That is why I simply use `if (response["message"].includes(" already exists."))` to handle the case when user already exists.

Received email from backend:
```
Your confirmation link is here: http://localhost:8000/api/authentication/activate/InF5dmloeUBlbWEtc29maWEuZXUi.YqdUfQ.wbFdqcet7Mm7dylFs3QNSkpw6IQ
```

If user already exists:
<img width="960" alt="user-signup1" src="https://user-images.githubusercontent.com/64476430/173389662-7125a57f-44e1-4b2b-9c36-657cad3690b0.png">

Upon clicking account activation link:
<img width="960" alt="user-signup2" src="https://user-images.githubusercontent.com/64476430/173389696-dc71302f-d11c-4c44-b4d0-14b48a2e1218.png">

