### PR TITLE
feat: finished the survey detail page, privacy policy, tnc

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -49,6 +49,7 @@
     "sass": "^1.32.7",
     "sass-loader": "^12.0.0",
     "style-loader": "^3.3.1",
+    "vue-friendly-iframe": "^0.20.0",
     "vue-meta": "^2.4.0",
     "vue-template-compiler": "^2.6.14",
     "vue-window-size": "0.6.2",

--- a/ui/src/assets/json/survey-data-sample.json
+++ b/ui/src/assets/json/survey-data-sample.json
@@ -2,6 +2,8 @@
   "data": {
     "title": "Cat owner survey 2022",
     "description": "Survey dedicated to all cat lovers in the world",
+    "isPublished": true,
+    "link": "http://www.google.com",
     "formBuilder": {
       "list": [
         {
@@ -101,11 +103,11 @@
         }
       ],
       "models": {
-        "input_e77197d15": "",
-        "input_6743209e4": "",
-        "radio_72b98a503": "",
-        "checkbox_5bc84abf1": [],
-        "slider_6b457fb73": "",
+        "input_e77197d15": "test",
+        "input_6743209e4": "test",
+        "radio_72b98a503": "Option_2",
+        "checkbox_5bc84abf1": ["Option_1", "Option_2"],
+        "slider_6b457fb73": 40,
         "text_f4f8d69e1": "This is a heading",
         "text_242ded82c": "This is a text"
       }
@@ -115,7 +117,7 @@
     "startDate": "2022-06-11 00:00:00.123456+00:00",
     "endDate": "2022-06-21 00:00:00.123456+00:00",
     "isPublic": true,
-    "emails": [],
+    "emails": ["test@user.com", "test@user2.com"],
     "isSurveySentAutomatically": false
   }
 }

--- a/ui/src/components/BottomSheet.vue
+++ b/ui/src/components/BottomSheet.vue
@@ -50,20 +50,20 @@ export default {
     value: Boolean,
     alignTitle: {
       type: String,
-      default: "left",
+      default: "left"
     },
     title: {
       type: String,
-      default: "",
+      default: ""
     },
     distance: {
       type: Number,
-      default: 100,
+      default: 100
     },
     fullscreen: {
       type: Boolean,
-      default: false,
-    },
+      default: false
+    }
   },
   computed: {
     show: {
@@ -72,15 +72,15 @@ export default {
       },
       set(value) {
         this.$emit("input", value);
-      },
-    },
+      }
+    }
   },
   methods: {
     onClickCloseButton() {
       this.show = !this.show;
       this.$emit("close");
-    },
-  },
+    }
+  }
 };
 </script>
 <style lang="scss">

--- a/ui/src/components/BottomSheet.vue
+++ b/ui/src/components/BottomSheet.vue
@@ -28,7 +28,7 @@
               elevation="2"
               class="s-bottom-sheet__close-button"
               text
-              @click="show = !show"
+              @click="onClickCloseButton"
             >
               <v-icon>mdi-close</v-icon>
             </v-btn>
@@ -50,20 +50,20 @@ export default {
     value: Boolean,
     alignTitle: {
       type: String,
-      default: "left"
+      default: "left",
     },
     title: {
       type: String,
-      default: ""
+      default: "",
     },
     distance: {
       type: Number,
-      default: 100
+      default: 100,
     },
     fullscreen: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
   computed: {
     show: {
@@ -72,9 +72,15 @@ export default {
       },
       set(value) {
         this.$emit("input", value);
-      }
-    }
-  }
+      },
+    },
+  },
+  methods: {
+    onClickCloseButton() {
+      this.show = !this.show;
+      this.$emit("close");
+    },
+  },
 };
 </script>
 <style lang="scss">

--- a/ui/src/components/ContentCard.vue
+++ b/ui/src/components/ContentCard.vue
@@ -48,45 +48,45 @@ export default {
   props: {
     title: {
       type: String,
-      default: ""
+      default: "",
     },
     description: {
       type: String,
-      default: ""
+      default: "",
     },
     image: {
       type: String,
-      default: null
+      default: null,
     },
     maxImageWidth: {
       type: Number,
-      default: 419
+      default: 419,
     },
     maxImageHeight: {
       type: Number,
-      default: 305
+      default: 305,
     },
     showPrimaryButton: {
       type: Boolean,
-      default: true
+      default: true,
     },
     primaryButtonText: {
       type: String,
-      default: "Back to home"
+      default: "Back to home",
     },
     onPrimaryButtonClickCallback: {
       type: Function,
       default() {
         return router.push("/");
-      }
-    }
+      },
+    },
   },
   methods: {
     onPrimaryButtonClick() {
       this.$emit("click:primary");
       this.onPrimaryButtonClickCallback.call();
-    }
-  }
+    },
+  },
 };
 </script>
 
@@ -106,10 +106,11 @@ export default {
 
   &__title {
     justify-content: center;
-    @include font-size(2);
+    @include font-size(1.5, "!important");
+    font-weight: 600;
 
     @media only screen and (max-width: map-get($breakpoints, "md")) {
-      @include font-size(1.25);
+      @include font-size(1.25, "!important");
     }
 
     @media only screen and (max-width: map-get($breakpoints, "xxs")) {
@@ -119,7 +120,7 @@ export default {
 
   &__description {
     color: $secondary-text-color;
-    @include font-size(1);
+    @include font-size(1, "!important");
 
     @media only screen and (max-width: map-get($breakpoints, "xxs")) {
       font-size: 0.8rem !important;

--- a/ui/src/components/ContentCard.vue
+++ b/ui/src/components/ContentCard.vue
@@ -48,45 +48,45 @@ export default {
   props: {
     title: {
       type: String,
-      default: "",
+      default: ""
     },
     description: {
       type: String,
-      default: "",
+      default: ""
     },
     image: {
       type: String,
-      default: null,
+      default: null
     },
     maxImageWidth: {
       type: Number,
-      default: 419,
+      default: 419
     },
     maxImageHeight: {
       type: Number,
-      default: 305,
+      default: 305
     },
     showPrimaryButton: {
       type: Boolean,
-      default: true,
+      default: true
     },
     primaryButtonText: {
       type: String,
-      default: "Back to home",
+      default: "Back to home"
     },
     onPrimaryButtonClickCallback: {
       type: Function,
       default() {
         return router.push("/");
-      },
-    },
+      }
+    }
   },
   methods: {
     onPrimaryButtonClick() {
       this.$emit("click:primary");
       this.onPrimaryButtonClickCallback.call();
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/ui/src/form-builder/components/GenerateForm.vue
+++ b/ui/src/form-builder/components/GenerateForm.vue
@@ -48,7 +48,7 @@
         <v-divider />
       </v-col>
       <v-col
-        v-if="formData.formBuilder.list.length"
+        v-if="formData.formBuilder.list.length && isSubmitButtonShown"
         cols="12"
         class="justify-flex--end"
       >
@@ -72,29 +72,33 @@ import GenerateFormItem from "./GenerateFormItem";
 export default {
   name: "GenerateForm",
   components: {
-    GenerateFormItem
+    GenerateFormItem,
   },
   props: {
     value: {
       type: Object,
       default() {
         return {};
-      }
+      },
     },
     formData: {
       type: Object,
       default() {
         return {};
-      }
+      },
+    },
+    isSubmitButtonShown: {
+      type: Boolean,
+      default: true,
     },
     canSubmit: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
   data() {
     return {
-      models: {}
+      models: {},
     };
   },
   watch: {
@@ -106,14 +110,14 @@ export default {
         this.$nextTick(() => {
           this.$forceUpdate();
         });
-      }
+      },
     },
     value: {
       deep: true,
       handler(val) {
         this.models = { ...this.models, ...val };
-      }
-    }
+      },
+    },
   },
   created() {
     this.generateModel(this.formData.formBuilder.list);
@@ -135,13 +139,13 @@ export default {
     onSubmitButtonClick() {
       this.$emit("submit", {
         models: this.models,
-        list: this.formData.formBuilder.list
+        list: this.formData.formBuilder.list,
       });
     },
     onInputChange(value, field) {
       this.$emit("on-change", field, value, this.models);
-    }
-  }
+    },
+  },
 };
 </script>
 <style lang="scss">

--- a/ui/src/form-builder/components/GenerateForm.vue
+++ b/ui/src/form-builder/components/GenerateForm.vue
@@ -34,6 +34,7 @@
       >
         <template v-for="(item, index) in formData.formBuilder.list">
           <generate-form-item
+            :disabled="disabled"
             :key="`${item.key}_${index}`"
             :models.sync="models"
             :widget="item"
@@ -86,6 +87,10 @@ export default {
       default() {
         return {};
       },
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
     },
     isSubmitButtonShown: {
       type: Boolean,

--- a/ui/src/form-builder/components/GenerateForm.vue
+++ b/ui/src/form-builder/components/GenerateForm.vue
@@ -34,8 +34,8 @@
       >
         <template v-for="(item, index) in formData.formBuilder.list">
           <generate-form-item
-            :disabled="disabled"
             :key="`${item.key}_${index}`"
+            :disabled="disabled"
             :models.sync="models"
             :widget="item"
             @input-change="onInputChange"
@@ -73,37 +73,37 @@ import GenerateFormItem from "./GenerateFormItem";
 export default {
   name: "GenerateForm",
   components: {
-    GenerateFormItem,
+    GenerateFormItem
   },
   props: {
     value: {
       type: Object,
       default() {
         return {};
-      },
+      }
     },
     formData: {
       type: Object,
       default() {
         return {};
-      },
+      }
     },
     disabled: {
       type: Boolean,
-      default: false,
+      default: false
     },
     isSubmitButtonShown: {
       type: Boolean,
-      default: true,
+      default: true
     },
     canSubmit: {
       type: Boolean,
-      default: false,
-    },
+      default: false
+    }
   },
   data() {
     return {
-      models: {},
+      models: {}
     };
   },
   watch: {
@@ -115,14 +115,14 @@ export default {
         this.$nextTick(() => {
           this.$forceUpdate();
         });
-      },
+      }
     },
     value: {
       deep: true,
       handler(val) {
         this.models = { ...this.models, ...val };
-      },
-    },
+      }
+    }
   },
   created() {
     this.generateModel(this.formData.formBuilder.list);
@@ -144,13 +144,13 @@ export default {
     onSubmitButtonClick() {
       this.$emit("submit", {
         models: this.models,
-        list: this.formData.formBuilder.list,
+        list: this.formData.formBuilder.list
       });
     },
     onInputChange(value, field) {
       this.$emit("on-change", field, value, this.models);
-    },
-  },
+    }
+  }
 };
 </script>
 <style lang="scss">

--- a/ui/src/form-builder/components/GenerateFormItem.vue
+++ b/ui/src/form-builder/components/GenerateFormItem.vue
@@ -30,6 +30,7 @@
           :ref="`${widget.type}_${widget.key}`"
           v-model.trim="dataModel"
           outlined
+          :disabled="disabled"
           :placeholder="widget.options.placeholder"
         />
       </v-col>
@@ -47,6 +48,7 @@
             v-for="(item, index) in widget.options.options"
             :key="index"
             :label="item.text"
+            :disabled="disabled"
             :value="item.value"
           />
         </v-radio-group>
@@ -62,6 +64,7 @@
             v-for="(item, index) in widget.options.options"
             :key="`checkbox_${index}`"
             v-model="dataModel"
+            :disabled="disabled"
             multiple
             :label="item.text"
             :value="item.value"
@@ -104,6 +107,7 @@
         <v-slider
           :ref="`${widget.type}_${widget.key}`"
           v-model="dataModel"
+          :disabled="disabled"
           :min="widget.options.min"
           :max="widget.options.max"
           :step="widget.options.step"
@@ -128,30 +132,34 @@ export default {
       type: Object,
       default() {
         return {};
-      }
+      },
     },
     models: {
       type: Object,
       default() {
         return {};
-      }
+      },
     },
     rules: {
       type: Object,
       default() {
         return {};
-      }
-    }
+      },
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
-      dataModel: this.models[this.widget.model]
+      dataModel: this.models[this.widget.model],
     };
   },
   computed: {
     isWidgetQuestionShown() {
       return this.widget.type != "text";
-    }
+    },
   },
   watch: {
     dataModel: {
@@ -160,17 +168,17 @@ export default {
         this.models[this.widget.model] = val;
         this.$emit("update:models", {
           ...this.models,
-          [this.widget.model]: val
+          [this.widget.model]: val,
         });
-      }
+      },
     },
     models: {
       deep: true,
       handler(val) {
         this.dataModel = val[this.widget.model];
-      }
-    }
-  }
+      },
+    },
+  },
 };
 </script>
 

--- a/ui/src/form-builder/components/GenerateFormItem.vue
+++ b/ui/src/form-builder/components/GenerateFormItem.vue
@@ -132,34 +132,34 @@ export default {
       type: Object,
       default() {
         return {};
-      },
+      }
     },
     models: {
       type: Object,
       default() {
         return {};
-      },
+      }
     },
     rules: {
       type: Object,
       default() {
         return {};
-      },
+      }
     },
     disabled: {
       type: Boolean,
-      default: false,
-    },
+      default: false
+    }
   },
   data() {
     return {
-      dataModel: this.models[this.widget.model],
+      dataModel: this.models[this.widget.model]
     };
   },
   computed: {
     isWidgetQuestionShown() {
       return this.widget.type != "text";
-    },
+    }
   },
   watch: {
     dataModel: {
@@ -168,17 +168,17 @@ export default {
         this.models[this.widget.model] = val;
         this.$emit("update:models", {
           ...this.models,
-          [this.widget.model]: val,
+          [this.widget.model]: val
         });
-      },
+      }
     },
     models: {
       deep: true,
       handler(val) {
         this.dataModel = val[this.widget.model];
-      },
-    },
-  },
+      }
+    }
+  }
 };
 </script>
 

--- a/ui/src/plugins/index.js
+++ b/ui/src/plugins/index.js
@@ -10,3 +10,4 @@ import "./vee-validate";
 import "./js-cookie";
 import "./vuedraggable";
 import "./vuetify-notify";
+import "./vue-friendly-iframe";

--- a/ui/src/plugins/vue-friendly-iframe.js
+++ b/ui/src/plugins/vue-friendly-iframe.js
@@ -1,0 +1,4 @@
+import Vue from "vue";
+import VueFriendlyIframe from "vue-friendly-iframe";
+
+Vue.use(VueFriendlyIframe);

--- a/ui/src/styles/mixins/_typography.scss
+++ b/ui/src/styles/mixins/_typography.scss
@@ -1,25 +1,24 @@
-@mixin font-size($multiply-by: 1) {
+@mixin font-size($multiply-by: 1, $property: "") {
   // font-size: $multiply-by*map-get($default-font-size, 'px');
   // font-size: $multiply-by*map-get($default-font-size, 'rem');
 
-  font-size: calc(var(--default-font-size-px)*$multiply-by);
-  font-size: calc(var(--default-font-size-rem)*$multiply-by);
+  font-size: calc(var(--default-font-size-px) * $multiply-by) #{$property};
+  font-size: calc(var(--default-font-size-rem) * $multiply-by) #{$property};
 }
 
-
-@function calculate-font-size($multiply-by: 1, $unit: 'rem') {
-  @return $multiply-by*map-get($default-font-size, $unit);
+@function calculate-font-size($multiply-by: 1, $unit: "rem") {
+  @return $multiply-by * map-get($default-font-size, $unit);
 }
 
 @mixin line-height {
-  line-height: map-get($default-line-height, 'px');
-  line-height: map-get($default-line-height, 'rem');
+  line-height: map-get($default-line-height, "px");
+  line-height: map-get($default-line-height, "rem");
 }
 
-@function calculate-line-height($multiply-by: 1, $unit: 'rem') {
-  @return $multiply-by*map-get($default-line-height, $unit);
+@function calculate-line-height($multiply-by: 1, $unit: "rem") {
+  @return $multiply-by * map-get($default-line-height, $unit);
 }
 
-@function calculate-space($multiply-by: 1, $unit: 'px') {
-  @return #{$multiply-by*map-get($default-spacing, $unit)}#{$unit};
+@function calculate-space($multiply-by: 1, $unit: "px") {
+  @return #{$multiply-by * map-get($default-spacing, $unit)}#{$unit};
 }

--- a/ui/src/styles/variables.js
+++ b/ui/src/styles/variables.js
@@ -1,5 +1,6 @@
 const style = {
   color: {
+    lightBlue: "#f7f9fd",
     primary: "#6200EE",
     secondary: "#9C27b0",
     accent: "#e91e63",
@@ -7,13 +8,13 @@ const style = {
     success: "#4CAF50",
     warning: "#FB8C00",
     error: "#FF5252",
-    disabled: "#F0F0F0"
+    disabled: "#F0F0F0",
   },
   overlay: {
     primary: "#bb86fc1f",
     success: "#e1fcef",
-    info: "#f0f1fa"
-  }
+    info: "#f0f1fa",
+  },
 };
 
 module.exports = { style };

--- a/ui/src/styles/variables.js
+++ b/ui/src/styles/variables.js
@@ -8,13 +8,13 @@ const style = {
     success: "#4CAF50",
     warning: "#FB8C00",
     error: "#FF5252",
-    disabled: "#F0F0F0",
+    disabled: "#F0F0F0"
   },
   overlay: {
     primary: "#bb86fc1f",
     success: "#e1fcef",
-    info: "#f0f1fa",
-  },
+    info: "#f0f1fa"
+  }
 };
 
 module.exports = { style };

--- a/ui/src/util/dates.js
+++ b/ui/src/util/dates.js
@@ -15,3 +15,18 @@ export const isTodayBeforeGivenDate = function (
 ) {
   return moment().isBefore(moment(givenDate, givenDateFormat));
 };
+
+export const getDurationFromTodayToGivenDate = function (
+  givenDate,
+  givenDateFormat = pythonDefaultDateFormat
+) {
+  let now = moment(new Date()); //todays date
+  let duration = moment.duration(now.diff(givenDate, givenDateFormat));
+  return {
+    duration,
+    minutes: duration.asMinutes(),
+    hours: duration.asHours(),
+    days: duration.asDays,
+    months: duration.asMonths(),
+  };
+};

--- a/ui/src/util/dates.js
+++ b/ui/src/util/dates.js
@@ -27,6 +27,6 @@ export const getDurationFromTodayToGivenDate = function (
     minutes: duration.asMinutes(),
     hours: duration.asHours(),
     days: duration.asDays(),
-    months: duration.asMonths(),
+    months: duration.asMonths()
   };
 };

--- a/ui/src/util/dates.js
+++ b/ui/src/util/dates.js
@@ -1,6 +1,7 @@
 import moment from "moment";
 
 const pythonDefaultDateFormat = "YYYY-MM-DD hh:mm:ss.SSSSSS+00:00";
+
 export const convertToStandardDate = function (
   value,
   givenFormat = pythonDefaultDateFormat

--- a/ui/src/util/dates.js
+++ b/ui/src/util/dates.js
@@ -21,12 +21,12 @@ export const getDurationFromTodayToGivenDate = function (
   givenDateFormat = pythonDefaultDateFormat
 ) {
   let now = moment(new Date()); //todays date
-  let duration = moment.duration(now.diff(givenDate, givenDateFormat));
+  let duration = moment.duration(moment(givenDate, givenDateFormat).diff(now));
   return {
     duration,
     minutes: duration.asMinutes(),
     hours: duration.asHours(),
-    days: duration.asDays,
+    days: duration.asDays(),
     months: duration.asMonths(),
   };
 };

--- a/ui/src/views/general/privacy-policy/PrivacyPolicyView.vue
+++ b/ui/src/views/general/privacy-policy/PrivacyPolicyView.vue
@@ -11,7 +11,7 @@
       >
         <v-card
           :elevation="isMobile? 0 : 2"
-          class="pa-5"
+          :class="{'pa-5': !isMobile}"
         >
           <v-card-title>Privacy Policy</v-card-title>
           <v-card-text>
@@ -19,7 +19,8 @@
               Please read this software's Privacy Policy carefully before using the software.
             </p>
             <v-divider class="mt-5" />
-            <p class="text-secondary mt-5 mb-5">{{ loremIpsum.long }}
+            <p class="text-secondary mt-5 mb-5">
+              {{ loremIpsum.long }}
             </p>
             <v-divider class="mb-5" />
             <p>
@@ -38,8 +39,8 @@ export default {
   name: "PrivacyPolicyView",
   data() {
     return {
-      loremIpsum,
+      loremIpsum
     };
-  },
+  }
 };
 </script>

--- a/ui/src/views/general/privacy-policy/PrivacyPolicyView.vue
+++ b/ui/src/views/general/privacy-policy/PrivacyPolicyView.vue
@@ -5,18 +5,41 @@
     tag="section"
   >
     <v-row justify="center">
-      <v-col cols="auto">
-        privacy policy view
+      <v-col
+        :cols="isMobile? 12 : 10"
+        class="text-left"
+      >
+        <v-card
+          :elevation="isMobile? 0 : 2"
+          class="pa-5"
+        >
+          <v-card-title>Privacy Policy</v-card-title>
+          <v-card-text>
+            <p>
+              Please read this software's Privacy Policy carefully before using the software.
+            </p>
+            <v-divider class="mt-5" />
+            <p class="text-secondary mt-5 mb-5">{{ loremIpsum.long }}
+            </p>
+            <v-divider class="mb-5" />
+            <p>
+              By accepting the terms and using this software, you are agreeing to be bound by the <strong>Privacy Policy</strong>.
+            </p>
+          </v-card-text>
+        </v-card>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script>
-  export default { name: "PrivacyPolicyView" };
+import loremIpsum from "@/assets/json/lorem-ipsum.json";
+export default {
+  name: "PrivacyPolicyView",
+  data() {
+    return {
+      loremIpsum,
+    };
+  },
+};
 </script>
-
-<style lang="scss">
-  #privacy-policy-view  {
-  }
-</style>

--- a/ui/src/views/general/survey-fill/SurveyFillView.vue
+++ b/ui/src/views/general/survey-fill/SurveyFillView.vue
@@ -104,20 +104,20 @@ export default {
       socialMedias: [
         {
           icon: "mdi-facebook",
-          text: "Facebook",
+          text: "Facebook"
         },
         {
           icon: "mdi-twitter",
-          text: "Twitter",
+          text: "Twitter"
         },
         {
           icon: "mdi-reddit",
-          text: "Reddit",
+          text: "Reddit"
         },
         {
           icon: "mdi-whatsapp",
-          text: "WhatsApp",
-        },
+          text: "WhatsApp"
+        }
       ],
       survey: {
         data: {
@@ -126,16 +126,16 @@ export default {
           link: "",
           formBuilder: {
             list: [],
-            models: {},
-          },
+            models: {}
+          }
         },
         config: {
           startDate: "",
           endDate: "",
           isPublic: false,
-          emails: [],
-        },
-      },
+          emails: []
+        }
+      }
     };
   },
   computed: {
@@ -146,7 +146,7 @@ export default {
       return this.survey.config.isPublic
         ? this.isWithinDate
         : this.token && this.hasPermission && this.isWithinDate;
-    },
+    }
   },
   created() {
     this.survey = { ...this.survey, ...surveyDataSample }; // delete this line later
@@ -172,8 +172,8 @@ export default {
       const isCopySuccess = copyText(this.survey.data.link);
 
       isCopySuccess && this.$notify.toast("Link has been copied to clipboard");
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/ui/src/views/general/survey-fill/SurveyFillView.vue
+++ b/ui/src/views/general/survey-fill/SurveyFillView.vue
@@ -4,7 +4,21 @@
     tag="section"
   >
     <v-row justify="center">
-      <v-col :cols="isMobile ? 12: 10">
+      <v-col
+        v-if="survey.data.isPublished"
+        cols="12"
+      >
+        <content-card
+          title="Sorry, this survey is not yet published"
+          description="Check your invite link or make sure you are granted the right
+ to fill in the survey"
+          :image="require('@assets/svg/man-woman-holding-mail.svg')"
+        />
+      </v-col>
+      <v-col
+        v-else
+        :cols="isMobile ? 12: 10"
+      >
         <template v-if="hasSubmitted">
           <content-card
             title="Thank you!"
@@ -39,8 +53,8 @@
                   class="survey-fill-view__link"
                   @click="onClickSurveyLink"
                 >
-                  <a :href="survey.data.link">
-                    {{ survey.data.link || 'http://www.google.com' }}
+                  <a :href="surveyLink">
+                    {{ surveyLink }}
                   </a>
                   <v-icon>mdi-content-copy </v-icon>
                 </div>
@@ -101,6 +115,7 @@ export default {
       todayDate: moment().format("DD MMM YYYY"),
       hasPermission: false,
       hasSubmitted: false,
+      baseUrl: window.location.origin,
       socialMedias: [
         {
           icon: "mdi-facebook",
@@ -124,6 +139,7 @@ export default {
           title: "",
           description: "",
           link: "",
+          isPublished: false,
           formBuilder: {
             list: [],
             models: {}
@@ -139,6 +155,12 @@ export default {
     };
   },
   computed: {
+    surveyId() {
+      return this.$route.params.id;
+    },
+    surveyLink() {
+      return `${this.baseUrl}/survey/${this.surveyId}`;
+    },
     isWithinDate() {
       return isTodayBeforeGivenDate(this.survey.config.endDate);
     },
@@ -169,7 +191,7 @@ export default {
       // download as pdf
     },
     onClickSurveyLink() {
-      const isCopySuccess = copyText(this.survey.data.link);
+      const isCopySuccess = copyText(this.surveyLink);
 
       isCopySuccess && this.$notify.toast("Link has been copied to clipboard");
     }

--- a/ui/src/views/general/terms-and-conditions/TermsAndConditionsView.vue
+++ b/ui/src/views/general/terms-and-conditions/TermsAndConditionsView.vue
@@ -11,7 +11,8 @@
       >
         <v-card
           :elevation="isMobile? 0 : 2"
-          class="pa-5"
+          class=""
+          :class="{'pa-5': !isMobile}"
         >
           <v-card-title>Terms and Conditions</v-card-title>
           <v-card-text>
@@ -19,7 +20,8 @@
               Please read this software's terms and conditions carefully before using the software.
             </p>
             <v-divider class="mt-5" />
-            <p class="text-secondary mt-5 mb-5">{{ loremIpsum.long }}
+            <p class="text-secondary mt-5 mb-5">
+              {{ loremIpsum.long }}
             </p>
             <v-divider class="mb-5" />
             <p>
@@ -38,8 +40,8 @@ export default {
   name: "TermsAndConditionsView",
   data() {
     return {
-      loremIpsum,
+      loremIpsum
     };
-  },
+  }
 };
 </script>

--- a/ui/src/views/general/terms-and-conditions/TermsAndConditionsView.vue
+++ b/ui/src/views/general/terms-and-conditions/TermsAndConditionsView.vue
@@ -5,18 +5,41 @@
     tag="section"
   >
     <v-row justify="center">
-      <v-col cols="auto">
-        terms and conditions view
+      <v-col
+        :cols="isMobile? 12 : 10"
+        class="text-left"
+      >
+        <v-card
+          :elevation="isMobile? 0 : 2"
+          class="pa-5"
+        >
+          <v-card-title>Terms and Conditions</v-card-title>
+          <v-card-text>
+            <p>
+              Please read this software's terms and conditions carefully before using the software.
+            </p>
+            <v-divider class="mt-5" />
+            <p class="text-secondary mt-5 mb-5">{{ loremIpsum.long }}
+            </p>
+            <v-divider class="mb-5" />
+            <p>
+              By accepting the terms and using this software, you are agreeing to be bound by the <strong>Terms and Conditions</strong>.
+            </p>
+          </v-card-text>
+        </v-card>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script>
-  export default { name: "TermsAndConditionsView" };
+import loremIpsum from "@/assets/json/lorem-ipsum.json";
+export default {
+  name: "TermsAndConditionsView",
+  data() {
+    return {
+      loremIpsum,
+    };
+  },
+};
 </script>
-
-<style lang="scss">
-  #terms-and-conditions-view  {
-  }
-</style>

--- a/ui/src/views/user/signup-thankyou/SignupThankyouView.vue
+++ b/ui/src/views/user/signup-thankyou/SignupThankyouView.vue
@@ -5,7 +5,7 @@
     tag="section"
   >
     <v-row justify="center">
-      <v-col cols="auto">
+      <v-col :cols="isMobile ? 12 : 10">
         <content-card
           title="Thanks for registering!"
           description="Please check your inbox or spams to confirm your registration"

--- a/ui/src/views/user/survey-detail/SurveyDetailView.vue
+++ b/ui/src/views/user/survey-detail/SurveyDetailView.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container
-    class="fill-height text-center survey-detail-view"
+    class="text-center survey-detail-view"
     tag="section"
     :class="{'pa-0': isMobile }"
   >
@@ -64,6 +64,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss">
-</style>

--- a/ui/src/views/user/survey-detail/SurveyDetailView.vue
+++ b/ui/src/views/user/survey-detail/SurveyDetailView.vue
@@ -52,15 +52,15 @@ export default {
       items: [
         {
           title: "Survey",
-          component: DetailQuestions,
+          component: DetailQuestions
         },
         {
           title: "Responses",
-          component: DetailResponses,
+          component: DetailResponses
         },
-        { title: "Summary", component: DetailSummary },
-      ],
+        { title: "Summary", component: DetailSummary }
+      ]
     };
-  },
+  }
 };
 </script>

--- a/ui/src/views/user/survey-detail/SurveyDetailView.vue
+++ b/ui/src/views/user/survey-detail/SurveyDetailView.vue
@@ -1,19 +1,63 @@
 <template>
   <v-container
-    id="survey-detail-view"
-    class="fill-height text-center"
+    class="fill-height text-center survey-detail-view"
     tag="section"
   >
     <v-row justify="center">
-      <v-col cols="auto">
-        survey detail view
+      <v-col :cols="isMobile? 12 : 10">
+        <v-card :elevation="isMobile? 0 : 2">
+          <v-tabs
+            v-model="tab"
+            class="survey-tab"
+            :centered="isMobile"
+            :grow="isMobile"
+          >
+            <v-tabs-slider color="primary" />
+            <v-tab
+              v-for="item in items"
+              :key="item.title"
+            >
+              {{ item.title }}
+            </v-tab>
+          </v-tabs>
+          <v-tabs-items v-model="tab">
+            <v-tab-item
+              v-for="item in items"
+              :key="item.title"
+            >
+              <component :is="item.component" />
+            </v-tab-item>
+          </v-tabs-items>
+        </v-card>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script>
-export default { name: "SurveyDetailView" };
+import DetailQuestions from "./components/DetailQuestions.vue";
+import DetailResponses from "./components/DetailResponses.vue";
+import DetailSummary from "./components/DetailSummary.vue";
+
+export default {
+  name: "SurveyDetailView",
+  data() {
+    return {
+      tab: "",
+      items: [
+        {
+          title: "Survey",
+          component: DetailQuestions,
+        },
+        {
+          title: "Responses",
+          component: DetailResponses,
+        },
+        { title: "Summary", component: DetailSummary },
+      ],
+    };
+  },
+};
 </script>
 
 <style lang="scss">

--- a/ui/src/views/user/survey-detail/SurveyDetailView.vue
+++ b/ui/src/views/user/survey-detail/SurveyDetailView.vue
@@ -2,9 +2,13 @@
   <v-container
     class="fill-height text-center survey-detail-view"
     tag="section"
+    :class="{'pa-0': isMobile }"
   >
     <v-row justify="center">
-      <v-col :cols="isMobile? 12 : 10">
+      <v-col
+        :cols="isMobile? 12 : 10"
+        :class="{'pa-0': isMobile }"
+      >
         <v-card :elevation="isMobile? 0 : 2">
           <v-tabs
             v-model="tab"
@@ -33,6 +37,7 @@
     </v-row>
   </v-container>
 </template>
+
 
 <script>
 import DetailQuestions from "./components/DetailQuestions.vue";

--- a/ui/src/views/user/survey-detail/components/DetailQuestions.vue
+++ b/ui/src/views/user/survey-detail/components/DetailQuestions.vue
@@ -303,10 +303,27 @@
       </div>
     </modal>
 
+    <bottom-sheet
+      v-model="isSurveySettingsBottomSheetShown"
+      title="Set survey privacy"
+      :fullscreen="true"
+      align-title="center"
+      @close="onSubmitSurveySettings"
+    >
+      <template #content>
+        <div class="pa-5">
+          <survey-settings
+            :can-set-date="false"
+            v-model="formData.config"
+          />
+        </div>
+      </template>
+    </bottom-sheet>
+
     <modal
       v-model="isDeleteModalShown"
       name="delete-modal"
-      title="Delete"
+      title="Warning"
       content="Are you sure you want to delete this survey? This action cannot be undone."
       primary-action-button-text="OK"
       @click:primary-action="onDeleteConfirmation"
@@ -337,6 +354,7 @@ export default {
       isDeleteModalShown: false,
       isSurveySettingsModalShown: false,
       isViewParticipantsModalShown: false,
+      isSurveySettingsBottomSheetShown: false,
       formData: {
         config: {},
       },
@@ -378,7 +396,11 @@ export default {
       this.$notify.toast("Survey has been successfully saved");
     },
     onClickSetSurveyPrivacyButton() {
-      this.isSurveySettingsModalShown = true;
+      if (this.isMobile) {
+        this.isSurveySettingsBottomSheetShown = true;
+      } else {
+        this.isSurveySettingsModalShown = true;
+      }
     },
     onClickViewParticipantsButton() {
       this.isViewParticipantsModalShown = true;

--- a/ui/src/views/user/survey-detail/components/DetailQuestions.vue
+++ b/ui/src/views/user/survey-detail/components/DetailQuestions.vue
@@ -20,7 +20,7 @@
           <template v-if="isMobile">
             <v-col
               cols="12"
-              class="text-right"
+              class="text-right pb-5 pt-0"
             >
               <strong class="d-block primary--text">
                 <v-icon
@@ -375,11 +375,13 @@ export default {
       return isTodayBeforeGivenDate(this.survey.config.startDate);
     },
     timeDifferenceBeforePublication() {
-      const { hours } = getDurationFromTodayToGivenDate(
+      const { hours, days } = getDurationFromTodayToGivenDate(
         this.survey.config.startDate
       );
+      const time =
+        hours < 24 ? `${hours.toFixed(0)} hours` : `${days.toFixed(0)} days`;
       return this.isStartDateBeforeToday
-        ? `To be published in ${hours} hours`
+        ? `To be published in ${time}`
         : `Published on ${convertToStandardDate(this.survey.config.startDate)}`;
     },
     surveyId() {

--- a/ui/src/views/user/survey-detail/components/DetailQuestions.vue
+++ b/ui/src/views/user/survey-detail/components/DetailQuestions.vue
@@ -1,0 +1,123 @@
+<template>
+  <v-container
+    fluid
+    tag="section"
+    class="detail-questions fill-height"
+  >
+    <v-row justify="start">
+      <v-col
+        cols="12"
+        class="detail-questions__info"
+      >
+        <v-row justify="start">
+          <v-col cols="3">
+            <v-icon>mdi-calendar</v-icon>
+            {{ survey.config.startDate | convertToStandardDate }} - {{ survey.config.endDate }}
+          </v-col>
+          <v-col cols="4">
+            <v-icon>
+              mdi-user
+            </v-icon>
+            <template v-if="survey.config.isPublic">
+              Public
+              <v-btn
+                text
+                small
+                outlined
+                rounded
+                class="text-secondary"
+              >
+                <v-icon
+                  class="pr-2"
+                  small
+                >mdi-content-copy</v-icon>
+                Copy link
+              </v-btn>
+            </template>
+            <template v-else>
+              Invite-only to {{ survey.config.emails.length }} participants
+            </template>
+          </v-col>
+          <v-col cols="5">
+            <strong class="d-block text-primary">
+              <v-icon
+                small
+                class="mr-2"
+              >mdi-clock</v-icon>
+              {{ timeDifferenceBeforePublication }}
+            </strong>
+            <v-btn
+              text
+              small
+              outlined
+              rounded
+              class="mr-2 text-secondary"
+            >
+              <v-icon
+                small
+                class="pr-2"
+              >mdi-edit</v-icon>
+              Edit survey
+            </v-btn>
+            <v-btn
+              text
+              small
+              outlined
+              rounded
+              class="text-secondary"
+            >
+              <v-icon
+                small
+                class="pr-2"
+                rounded
+              >mdi-trash</v-icon>
+              <u>Delete survey</u>
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-col>
+      <v-col cols="12">
+        <generate-form
+          ref="generateForm"
+          :form-data="survey.data"
+          :value="survey.data.formBuilder.models"
+          :is-submit-button-shown="false"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import surveyDataSample from "@/assets/json/survey-data-sample.json";
+import GenerateForm from "@/form-builder/components/GenerateForm";
+import { isTodayBeforeGivenDate } from "@/util/dates";
+
+export default {
+  name: "DetailQuestions",
+  components: {
+    GenerateForm,
+  },
+  data() {
+    return {
+      survey: {
+        data: {
+          isPublished: true,
+        },
+        config: {},
+      },
+    };
+  },
+  created() {
+    this.survey = { ...this.survey, ...surveyDataSample };
+    fetch("http://localhost:8000/api/authentication/signup", {
+      method: "POST",
+    }).then((response) => {
+      console.log(response);
+    });
+  },
+  computed: {
+    timeDifferenceBeforePublication() {},
+  },
+};
+</script>

--- a/ui/src/views/user/survey-detail/components/DetailQuestions.vue
+++ b/ui/src/views/user/survey-detail/components/DetailQuestions.vue
@@ -38,7 +38,9 @@
                 <v-icon
                   small
                   class="mr-1"
-                >mdi-calendar</v-icon>
+                >
+                  mdi-calendar
+                </v-icon>
                 {{ survey.config.startDate | standardDate }} - {{ survey.config.endDate | standardDate }}
               </p>
             </v-col>
@@ -62,7 +64,9 @@
                   <v-icon
                     class="pr-2"
                     small
-                  >mdi-content-copy</v-icon>
+                  >
+                    mdi-content-copy
+                  </v-icon>
                   Copy link
                 </v-btn>
               </template>
@@ -79,7 +83,9 @@
                   <v-icon
                     class="pr-2"
                     small
-                  >mdi-account-outline</v-icon>
+                  >
+                    mdi-account-outline
+                  </v-icon>
                   View participants
                 </v-btn>
               </template>
@@ -94,28 +100,32 @@
                 small
                 outlined
                 rounded
-                @click="onClickSetSurveyPrivacyButton"
                 class="mr-2 text-secondary text-none"
+                @click="onClickSetSurveyPrivacyButton"
               >
                 <v-icon
                   small
                   class="mr-2"
-                >mdi-lock</v-icon>
+                >
+                  mdi-lock
+                </v-icon>
                 Set survey privacy
               </v-btn>
               <v-btn
+                v-else
                 text
                 small
                 outlined
                 rounded
                 class="mr-2 text-secondary text-none"
-                v-else
                 @click="onClickEditSurveyButton"
               >
                 <v-icon
                   small
                   class="pr-2"
-                >mdi-pencil</v-icon>
+                >
+                  mdi-pencil
+                </v-icon>
                 Edit survey
               </v-btn>
               <v-btn
@@ -128,7 +138,9 @@
                   small
                   class="pr-2"
                   rounded
-                >mdi-delete</v-icon>
+                >
+                  mdi-delete
+                </v-icon>
                 <u>Delete survey</u>
               </v-btn>
             </v-col>
@@ -141,7 +153,9 @@
                 <v-icon
                   small
                   class="mr-1"
-                >mdi-calendar</v-icon>
+                >
+                  mdi-calendar
+                </v-icon>
                 {{ survey.config.startDate | standardDate }} - {{ survey.config.endDate | standardDate }}
               </p>
             </v-col>
@@ -165,7 +179,9 @@
                   <v-icon
                     class="pr-2"
                     small
-                  >mdi-content-copy</v-icon>
+                  >
+                    mdi-content-copy
+                  </v-icon>
                   Copy link
                 </v-btn>
               </template>
@@ -183,7 +199,9 @@
                   <v-icon
                     class="pr-2"
                     small
-                  >mdi-account-outline</v-icon>
+                  >
+                    mdi-account-outline
+                  </v-icon>
                   View participants
                 </v-btn>
               </template>
@@ -208,22 +226,26 @@
                 class="text-secondary text-none mr-2"
                 @click="onClickSetSurveyPrivacyButton"
               >
-                <v-icon small>mdi-share</v-icon>
+                <v-icon small>
+                  mdi-share
+                </v-icon>
                 Set survey privacy
               </v-btn>
               <v-btn
+                v-else
                 text
                 small
                 outlined
                 rounded
                 class="mr-2 text-secondary text-none"
-                v-else
                 @click="onClickEditSurveyButton"
               >
                 <v-icon
                   small
                   class="pr-2"
-                >mdi-pencil</v-icon>
+                >
+                  mdi-pencil
+                </v-icon>
                 Edit survey
               </v-btn>
               <v-btn
@@ -236,7 +258,9 @@
                   small
                   class="pr-2"
                   rounded
-                >mdi-delete</v-icon>
+                >
+                  mdi-delete
+                </v-icon>
                 <u>Delete survey</u>
               </v-btn>
             </v-col>
@@ -285,7 +309,6 @@
             </template>
           </v-list-item-group>
         </v-list>
-
       </v-card>
     </modal>
 
@@ -297,8 +320,8 @@
     >
       <div class="pa-5">
         <survey-settings
-          :can-set-date="false"
           v-model="formData.config"
+          :can-set-date="false"
         />
       </div>
     </modal>
@@ -313,8 +336,8 @@
       <template #content>
         <div class="pa-5">
           <survey-settings
-            :can-set-date="false"
             v-model="formData.config"
+            :can-set-date="false"
           />
         </div>
       </template>
@@ -339,7 +362,7 @@ import SurveySettings from "@/views/user/survey-edit/components/SurveySettings";
 import {
   isTodayBeforeGivenDate,
   convertToStandardDate,
-  getDurationFromTodayToGivenDate,
+  getDurationFromTodayToGivenDate
 } from "@/util/dates";
 import copyText from "@util/copy";
 
@@ -347,7 +370,7 @@ export default {
   name: "DetailQuestions",
   components: {
     GenerateForm,
-    SurveySettings,
+    SurveySettings
   },
   data() {
     return {
@@ -355,20 +378,18 @@ export default {
       isSurveySettingsModalShown: false,
       isViewParticipantsModalShown: false,
       isSurveySettingsBottomSheetShown: false,
+      baseUrl: window.location.origin,
       formData: {
-        config: {},
+        config: {}
       },
       survey: {
         data: {
           link: "",
-          isPublished: false,
+          isPublished: false
         },
-        config: {},
-      },
+        config: {}
+      }
     };
-  },
-  created() {
-    this.survey = { ...this.survey, ...surveyDataSample };
   },
   computed: {
     isStartDateBeforeToday() {
@@ -387,6 +408,12 @@ export default {
     surveyId() {
       return this.$route.params.id;
     },
+    surveyLink() {
+      return `${this.baseUrl}/survey/${this.surveyId}`;
+    }
+  },
+  created() {
+    this.survey = { ...this.survey, ...surveyDataSample };
   },
   methods: {
     onSubmitSurveySettings() {
@@ -415,7 +442,7 @@ export default {
       this.$router.push("/user/surveys");
     },
     onClickCopyLinkButton() {
-      const isSuccess = copyText(this.survey.data.link);
+      const isSuccess = copyText(this.surveyLink);
 
       isSuccess &&
         this.$notify.toast("Link has been succesfully copied to clipboard");
@@ -425,8 +452,8 @@ export default {
     },
     onClickEditSurveyButton() {
       this.$router.push(`/user/surveys/${this.surveyId}/edit`);
-    },
-  },
+    }
+  }
 };
 </script>
 <style lang="scss">

--- a/ui/src/views/user/survey-detail/components/DetailQuestions.vue
+++ b/ui/src/views/user/survey-detail/components/DetailQuestions.vue
@@ -4,105 +4,346 @@
     tag="section"
     class="detail-questions fill-height"
   >
-    <v-row justify="start">
+    <v-row
+      justify="start"
+      align="center"
+    >
       <v-col
         cols="12"
         class="detail-questions__info"
       >
-        <v-row justify="start">
-          <v-col cols="3">
-            <v-icon>mdi-calendar</v-icon>
-            {{ survey.config.startDate | convertToStandardDate }} - {{ survey.config.endDate }}
-          </v-col>
-          <v-col cols="4">
-            <v-icon>
-              mdi-user
-            </v-icon>
-            <template v-if="survey.config.isPublic">
-              Public
+        <v-row
+          justify="start"
+          class="pa-5"
+        >
+          <!--start of mobile template -->
+          <template v-if="isMobile">
+            <v-col
+              cols="12"
+              class="text-right"
+            >
+              <strong class="d-block primary--text">
+                <v-icon
+                  small
+                  class="mr-2 primary--text"
+                >mdi-clock</v-icon>
+                {{ timeDifferenceBeforePublication }}
+              </strong>
+            </v-col>
+            <v-col
+              cols="12"
+              class="text-left py-0"
+            >
+              <p class="ma-0 text-left">
+                <v-icon
+                  small
+                  class="mr-1"
+                >mdi-calendar</v-icon>
+                {{ survey.config.startDate | standardDate }} - {{ survey.config.endDate | standardDate }}
+              </p>
+            </v-col>
+            <v-col
+              cols="12"
+              class="text-left"
+            >
+              <v-icon small>
+                mdi-account-outline
+              </v-icon>
+              <template v-if="survey.config.isPublic">
+                Public
+                <v-btn
+                  text
+                  small
+                  outlined
+                  rounded
+                  class="text-secondary text-none ml-2"
+                  @click="onClickCopyLinkButton"
+                >
+                  <v-icon
+                    class="pr-2"
+                    small
+                  >mdi-content-copy</v-icon>
+                  Copy link
+                </v-btn>
+              </template>
+              <template v-else>
+                Invite-only to {{ survey.config.emails.length }} participants
+                <v-btn
+                  text
+                  small
+                  outlined
+                  rounded
+                  class="text-secondary text-none ml-2"
+                  @click="onClickViewParticipantsButton"
+                >
+                  <v-icon
+                    class="pr-2"
+                    small
+                  >mdi-account-outline</v-icon>
+                  View participants
+                </v-btn>
+              </template>
+            </v-col>
+            <v-col
+              cols="12"
+              class="text-left "
+            >
+              <v-btn
+                v-if="survey.data.isPublished"
+                text
+                small
+                outlined
+                rounded
+                @click="onClickSetSurveyPrivacyButton"
+                class="mr-2 text-secondary text-none"
+              >
+                <v-icon
+                  small
+                  class="mr-2"
+                >mdi-lock</v-icon>
+                Set survey privacy
+              </v-btn>
               <v-btn
                 text
                 small
                 outlined
                 rounded
-                class="text-secondary"
+                class="mr-2 text-secondary text-none"
+                v-else
+                @click="onClickEditSurveyButton"
               >
                 <v-icon
-                  class="pr-2"
                   small
-                >mdi-content-copy</v-icon>
-                Copy link
+                  class="pr-2"
+                >mdi-pencil</v-icon>
+                Edit survey
               </v-btn>
-            </template>
-            <template v-else>
-              Invite-only to {{ survey.config.emails.length }} participants
-            </template>
-          </v-col>
-          <v-col cols="5">
-            <strong class="d-block text-primary">
-              <v-icon
+              <v-btn
+                text
                 small
-                class="mr-2"
-              >mdi-clock</v-icon>
-              {{ timeDifferenceBeforePublication }}
-            </strong>
-            <v-btn
-              text
-              small
-              outlined
-              rounded
-              class="mr-2 text-secondary"
+                class="text-secondary text-none"
+                @click="onClickDeleteSurveyButton"
+              >
+                <v-icon
+                  small
+                  class="pr-2"
+                  rounded
+                >mdi-delete</v-icon>
+                <u>Delete survey</u>
+              </v-btn>
+            </v-col>
+          </template>
+          <!--end of mobile template -->
+          <!-- start of desktop info card-->
+          <template v-else>
+            <v-col cols="4">
+              <p class="ma-0 text-left">
+                <v-icon
+                  small
+                  class="mr-1"
+                >mdi-calendar</v-icon>
+                {{ survey.config.startDate | standardDate }} - {{ survey.config.endDate | standardDate }}
+              </p>
+            </v-col>
+            <v-col
+              cols="4"
+              class="text-left"
             >
-              <v-icon
-                small
-                class="pr-2"
-              >mdi-edit</v-icon>
-              Edit survey
-            </v-btn>
-            <v-btn
-              text
-              small
-              outlined
-              rounded
-              class="text-secondary"
+              <v-icon small>
+                mdi-account-outline
+              </v-icon>
+              <template v-if="survey.config.isPublic">
+                Public
+                <v-btn
+                  text
+                  small
+                  outlined
+                  rounded
+                  class="text-secondary text-none ml-2"
+                  @click="onClickCopyLinkButton"
+                >
+                  <v-icon
+                    class="pr-2"
+                    small
+                  >mdi-content-copy</v-icon>
+                  Copy link
+                </v-btn>
+              </template>
+              <template v-else>
+                Invite-only to {{ survey.config.emails.length }} participants
+
+                <v-btn
+                  text
+                  small
+                  outlined
+                  rounded
+                  class="text-secondary text-none ml-2"
+                  @click="onClickViewParticipantsButton"
+                >
+                  <v-icon
+                    class="pr-2"
+                    small
+                  >mdi-account-outline</v-icon>
+                  View participants
+                </v-btn>
+              </template>
+            </v-col>
+            <v-col
+              cols="4"
+              class="text-right"
             >
-              <v-icon
+              <strong class="d-block primary--text mb-10">
+                <v-icon
+                  small
+                  class="mr-2 primary--text"
+                >mdi-clock</v-icon>
+                {{ timeDifferenceBeforePublication }}
+              </strong>
+              <v-btn
+                v-if="survey.data.isPublished"
+                text
                 small
-                class="pr-2"
+                outlined
                 rounded
-              >mdi-trash</v-icon>
-              <u>Delete survey</u>
-            </v-btn>
-          </v-col>
+                class="text-secondary text-none mr-2"
+                @click="onClickSetSurveyPrivacyButton"
+              >
+                <v-icon small>mdi-share</v-icon>
+                Set survey privacy
+              </v-btn>
+              <v-btn
+                text
+                small
+                outlined
+                rounded
+                class="mr-2 text-secondary text-none"
+                v-else
+                @click="onClickEditSurveyButton"
+              >
+                <v-icon
+                  small
+                  class="pr-2"
+                >mdi-pencil</v-icon>
+                Edit survey
+              </v-btn>
+              <v-btn
+                text
+                small
+                class="text-secondary text-none pa-0"
+                @click="onClickDeleteSurveyButton"
+              >
+                <v-icon
+                  small
+                  class="pr-2"
+                  rounded
+                >mdi-delete</v-icon>
+                <u>Delete survey</u>
+              </v-btn>
+            </v-col>
+          </template>
+          <!--end of desktop info card -->
         </v-row>
       </v-col>
       <v-col cols="12">
         <generate-form
           ref="generateForm"
+          :disabled="true"
           :form-data="survey.data"
           :value="survey.data.formBuilder.models"
           :is-submit-button-shown="false"
         />
       </v-col>
     </v-row>
+
+    <modal
+      v-model="isViewParticipantsModalShown"
+      name="view-participants-modal"
+      :title="`Survey Participants (${survey.config.emails.length})`"
+    >
+      <v-card
+        elevation="0"
+        class="pa-5"
+      >
+        <v-list>
+          <v-list-item-group multiple>
+            <template v-for="(item, i) in survey.config.emails">
+              <v-list-item
+                :key="`item-${i}`"
+                :value="item"
+                active-class="deep-purple--text text--accent-4"
+              >
+                <v-list-item-content>
+                  <v-list-item-title class="text-left">
+                    {{ item }}
+                  </v-list-item-title>
+                </v-list-item-content>
+              </v-list-item>
+              <v-divider
+                v-if="i <= survey.config.emails.length - 2"
+                :key="`divider-${i}`"
+              />
+            </template>
+          </v-list-item-group>
+        </v-list>
+
+      </v-card>
+    </modal>
+
+    <modal
+      v-model="isSurveySettingsModalShown"
+      title="Survey settings"
+      primary-action-button-text="save"
+      @click:primary-action="onSubmitSurveySettings"
+    >
+      <div class="pa-5">
+        <survey-settings
+          :can-set-date="false"
+          v-model="formData.config"
+        />
+      </div>
+    </modal>
+
+    <modal
+      v-model="isDeleteModalShown"
+      name="delete-modal"
+      title="Delete"
+      content="Are you sure you want to delete this survey? This action cannot be undone."
+      primary-action-button-text="OK"
+      @click:primary-action="onDeleteConfirmation"
+    />
   </v-container>
 </template>
+
 
 <script>
 import surveyDataSample from "@/assets/json/survey-data-sample.json";
 import GenerateForm from "@/form-builder/components/GenerateForm";
-import { isTodayBeforeGivenDate } from "@/util/dates";
+import SurveySettings from "@/views/user/survey-edit/components/SurveySettings";
+import {
+  isTodayBeforeGivenDate,
+  convertToStandardDate,
+  getDurationFromTodayToGivenDate,
+} from "@/util/dates";
+import copyText from "@util/copy";
 
 export default {
   name: "DetailQuestions",
   components: {
     GenerateForm,
+    SurveySettings,
   },
   data() {
     return {
+      isDeleteModalShown: false,
+      isSurveySettingsModalShown: false,
+      isViewParticipantsModalShown: false,
+      formData: {
+        config: {},
+      },
       survey: {
         data: {
-          isPublished: true,
+          link: "",
+          isPublished: false,
         },
         config: {},
       },
@@ -110,14 +351,64 @@ export default {
   },
   created() {
     this.survey = { ...this.survey, ...surveyDataSample };
-    fetch("http://localhost:8000/api/authentication/signup", {
-      method: "POST",
-    }).then((response) => {
-      console.log(response);
-    });
   },
   computed: {
-    timeDifferenceBeforePublication() {},
+    isStartDateBeforeToday() {
+      return isTodayBeforeGivenDate(this.survey.config.startDate);
+    },
+    timeDifferenceBeforePublication() {
+      const { hours } = getDurationFromTodayToGivenDate(
+        this.survey.config.startDate
+      );
+      return this.isStartDateBeforeToday
+        ? `To be published in ${hours} hours`
+        : `Published on ${convertToStandardDate(this.survey.config.startDate)}`;
+    },
+    surveyId() {
+      return this.$route.params.id;
+    },
+  },
+  methods: {
+    onSubmitSurveySettings() {
+      // get data from survey settings
+      // submit
+      // show notif
+      // reload
+      this.isSurveySettingsModalShown = false;
+      this.$notify.toast("Survey has been successfully saved");
+    },
+    onClickSetSurveyPrivacyButton() {
+      this.isSurveySettingsModalShown = true;
+    },
+    onClickViewParticipantsButton() {
+      this.isViewParticipantsModalShown = true;
+    },
+    onDeleteConfirmation() {
+      // fetch delete api
+      // if ok, show notif, redirect to user/surveys page
+      // else stays
+      this.$notify.toast("Survey has been successfully deleted");
+      this.$router.push("/user/surveys");
+    },
+    onClickCopyLinkButton() {
+      const isSuccess = copyText(this.survey.data.link);
+
+      isSuccess &&
+        this.$notify.toast("Link has been succesfully copied to clipboard");
+    },
+    onClickDeleteSurveyButton() {
+      this.isDeleteModalShown = true;
+    },
+    onClickEditSurveyButton() {
+      this.$router.push(`/user/surveys/${this.surveyId}/edit`);
+    },
   },
 };
 </script>
+<style lang="scss">
+.detail-questions {
+  &__info {
+    background-color: $grayish-white;
+  }
+}
+</style>

--- a/ui/src/views/user/survey-detail/components/DetailResponses.vue
+++ b/ui/src/views/user/survey-detail/components/DetailResponses.vue
@@ -13,8 +13,12 @@
           cols="7"
           class="text-left detail-responses__info"
         >
-          <h1 class="title">{{ survey.data.title }} </h1>
-          <p class="ma-0 description text-secondary">{{ survey.data.description }} </p>
+          <h1 class="title">
+            {{ survey.data.title }}
+          </h1>
+          <p class="ma-0 description text-secondary">
+            {{ survey.data.description }}
+          </p>
         </v-col>
         <v-col
           cols="5"
@@ -24,7 +28,6 @@
             :block="isMobile"
             small
             height="44"
-            :disabled="!filteredResponses.length"
             class="v-btn--accent"
             @click="onClickDownloadButton"
           >
@@ -38,40 +41,11 @@
           cols="12"
           class="mt-10"
         >
-          <v-data-table
-            :headers="tableHeaders"
-            :items="filteredResponses"
-            item-key="name"
-            class="detail-responses-table"
-            :search="keyword"
-          >
-            <template #top>
-              <v-row
-                justify="start"
-                class="detail-responses-table__top"
-              >
-                <v-col cols="auto">
-                  <v-text-field
-                    v-model.trim="keyword"
-                    solo
-                    dense
-                    flat
-                    :outlined="isMobile"
-                    class="detail-responses-search mb-2"
-                    :class="[isMobile? '--is-mobile' : '--is-desktop']"
-                    prepend-inner-icon="mdi-magnify"
-                    label="Search responses..."
-                  />
-                </v-col>
-              </v-row>
-            </template>
-            <template #item.submissionDate="{ item }">
-              {{ item.submissionDate | standardDate }}
-            </template>
-          </v-data-table>
-
+          <vue-friendly-iframe
+            :src="responsesUrl"
+            @load="onLoadIframe"
+          />
         </v-col>
-
       </v-row>
     </v-container>
   </div>
@@ -84,56 +58,23 @@ export default {
   name: "DetailResponses",
   data() {
     return {
-      surveyDataSample,
       keyword: "",
-      responses: [],
+      responsesUrl: "http://localhost:8000/",
       survey: {
         data: {
           title: "",
           description: "",
           formBuilder: {
             list: [],
-            models: {},
-          },
+            models: {}
+          }
         },
-        config: {},
-      },
+        config: {}
+      }
     };
   },
   created() {
     this.survey = { ...this.survey, ...surveyDataSample };
-    this.createMockResponses();
-  },
-  computed: {
-    filteredResponses() {
-      let responses = this.keyword
-        ? this.responses.filter((response) => {
-            return JSON.stringify(response)
-              .toLowerCase()
-              .includes(this.keyword);
-          })
-        : this.responses;
-      return responses;
-    },
-    tableHeaders() {
-      const headers = [
-        { text: "Submission date", value: "submissionDate", width: 150 },
-      ];
-      const questions = this.survey.data.formBuilder.list.map(
-        (widget, index) => {
-          let question = `Q${index + 1}: ${
-            widget.question || "No question given"
-          }`;
-          return {
-            text: question,
-            value: widget.model,
-            width: 200,
-          };
-        }
-      );
-
-      return headers.concat(questions);
-    },
   },
   methods: {
     onClickDownloadButton() {
@@ -141,76 +82,18 @@ export default {
       // fetch the api
       this.$notify.toast("File has been downloaded");
     },
-    createMockResponses() {
-      let responses = [];
-      let models = _.cloneDeep(this.survey.data.formBuilder.models);
-      for (let i = 0; i < 10; i++) {
-        models["submissionDate"] = "2022-06-11 00:00:00.123456+00:00";
-        responses.push(models);
-      }
-      responses.forEach((response) => {
-        Object.keys(response).forEach((model) => {
-          const widget = this.survey.data.formBuilder.list.find(
-            (formWidget) => formWidget.model === model
-          );
-          if (model.includes("radio")) {
-            let option = widget.options.options.find(
-              (option) => option.value === response[model]
-            );
-            response[model] = option ? option.text : response[model];
-          }
-        });
-      });
-
-      this.responses = _.cloneDeep(responses);
-      console.log(JSON.stringify(this.responses));
-    },
-  },
+    onLoadIframe() {
+      // do something
+    }
+  }
 };
 </script>
 <style lang="scss">
-.detail-responses-table {
-  &__top {
-    background-color: $light-blue;
-    margin: 0;
-    overflow: hidden;
-  }
-
-  .v-data-table-header {
-    background-color: $light-blue;
-
-    th[role="columnheader"] {
-      text-transform: uppercase;
-      vertical-align: top;
-
-      > span {
-        font-weight: 600;
-      }
-    }
-  }
-}
-
-.detail-responses-search {
-  &.--is-desktop {
-    .v-input__slot {
-      box-shadow: none !important;
-      border: 1px solid $light-gray;
-    }
-  }
-
-  .v-text-field__details {
-    display: none;
-  }
-}
-
 .detail-responses {
-  &__info {
-    .title {
-      @include font-size(1.5);
-    }
-
-    .description {
-      @include font-size(1);
+  .vue-friendly-iframe {
+    iframe {
+      width: 100%;
+      min-height: 500px;
     }
   }
 }

--- a/ui/src/views/user/survey-detail/components/DetailResponses.vue
+++ b/ui/src/views/user/survey-detail/components/DetailResponses.vue
@@ -53,11 +53,10 @@
                 <v-col cols="auto">
                   <v-text-field
                     v-model.trim="keyword"
-                    rounded
-                    :background-color="style.color.lightBlue"
                     solo
                     dense
-                    outlined
+                    flat
+                    :outlined="isMobile"
                     class="detail-responses-search mb-2"
                     :class="[isMobile? '--is-mobile' : '--is-desktop']"
                     prepend-inner-icon="mdi-magnify"

--- a/ui/src/views/user/survey-detail/components/DetailResponses.vue
+++ b/ui/src/views/user/survey-detail/components/DetailResponses.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="detail-responses">
+    responses
+  </div>
+</template>
+
+<script>
+export default { name: "DetailResponses" };
+</script>

--- a/ui/src/views/user/survey-detail/components/DetailResponses.vue
+++ b/ui/src/views/user/survey-detail/components/DetailResponses.vue
@@ -1,9 +1,218 @@
 <template>
   <div class="detail-responses">
-    responses
+    <v-container
+      fluid
+      tag="section"
+      class="pa-5"
+    >
+      <v-row
+        justify="start"
+        class="mt-2"
+      >
+        <v-col
+          cols="7"
+          class="text-left detail-responses__info"
+        >
+          <h1 class="title">{{ survey.data.title }} </h1>
+          <p class="ma-0 description text-secondary">{{ survey.data.description }} </p>
+        </v-col>
+        <v-col
+          cols="5"
+          class="text-right"
+        >
+          <v-btn
+            :block="isMobile"
+            small
+            height="44"
+            :disabled="!filteredResponses.length"
+            class="v-btn--accent"
+            @click="onClickDownloadButton"
+          >
+            <v-icon class="pr-1">
+              mdi-download
+            </v-icon>
+            DOWNLOAD AS CSV
+          </v-btn>
+        </v-col>
+        <v-col
+          cols="12"
+          class="mt-10"
+        >
+          <v-data-table
+            :headers="tableHeaders"
+            :items="filteredResponses"
+            item-key="name"
+            class="detail-responses-table"
+            :search="keyword"
+          >
+            <template #top>
+              <v-row
+                justify="start"
+                class="detail-responses-table__top"
+              >
+                <v-col cols="auto">
+                  <v-text-field
+                    v-model.trim="keyword"
+                    rounded
+                    :background-color="style.color.lightBlue"
+                    solo
+                    dense
+                    outlined
+                    class="detail-responses-search mb-2"
+                    :class="[isMobile? '--is-mobile' : '--is-desktop']"
+                    prepend-inner-icon="mdi-magnify"
+                    label="Search responses..."
+                  />
+                </v-col>
+              </v-row>
+            </template>
+            <template #item.submissionDate="{ item }">
+              {{ item.submissionDate | standardDate }}
+            </template>
+          </v-data-table>
+
+        </v-col>
+
+      </v-row>
+    </v-container>
   </div>
 </template>
 
 <script>
-export default { name: "DetailResponses" };
+import surveyDataSample from "@/assets/json/survey-data-sample.json";
+
+export default {
+  name: "DetailResponses",
+  data() {
+    return {
+      surveyDataSample,
+      keyword: "",
+      responses: [],
+      survey: {
+        data: {
+          title: "",
+          description: "",
+          formBuilder: {
+            list: [],
+            models: {},
+          },
+        },
+        config: {},
+      },
+    };
+  },
+  created() {
+    this.survey = { ...this.survey, ...surveyDataSample };
+    this.createMockResponses();
+  },
+  computed: {
+    filteredResponses() {
+      let responses = this.keyword
+        ? this.responses.filter((response) => {
+            return JSON.stringify(response)
+              .toLowerCase()
+              .includes(this.keyword);
+          })
+        : this.responses;
+      return responses;
+    },
+    tableHeaders() {
+      const headers = [
+        { text: "Submission date", value: "submissionDate", width: 150 },
+      ];
+      const questions = this.survey.data.formBuilder.list.map(
+        (widget, index) => {
+          let question = `Q${index + 1}: ${
+            widget.question || "No question given"
+          }`;
+          return {
+            text: question,
+            value: widget.model,
+            width: 200,
+          };
+        }
+      );
+
+      return headers.concat(questions);
+    },
+  },
+  methods: {
+    onClickDownloadButton() {
+      // do something
+      // fetch the api
+      this.$notify.toast("File has been downloaded");
+    },
+    createMockResponses() {
+      let responses = [];
+      let models = _.cloneDeep(this.survey.data.formBuilder.models);
+      for (let i = 0; i < 10; i++) {
+        models["submissionDate"] = "2022-06-11 00:00:00.123456+00:00";
+        responses.push(models);
+      }
+      responses.forEach((response) => {
+        Object.keys(response).forEach((model) => {
+          const widget = this.survey.data.formBuilder.list.find(
+            (formWidget) => formWidget.model === model
+          );
+          if (model.includes("radio")) {
+            let option = widget.options.options.find(
+              (option) => option.value === response[model]
+            );
+            response[model] = option ? option.text : response[model];
+          }
+        });
+      });
+
+      this.responses = _.cloneDeep(responses);
+      console.log(JSON.stringify(this.responses));
+    },
+  },
+};
 </script>
+<style lang="scss">
+.detail-responses-table {
+  &__top {
+    background-color: $light-blue;
+    margin: 0;
+    overflow: hidden;
+  }
+
+  .v-data-table-header {
+    background-color: $light-blue;
+
+    th[role="columnheader"] {
+      text-transform: uppercase;
+      vertical-align: top;
+
+      > span {
+        font-weight: 600;
+      }
+    }
+  }
+}
+
+.detail-responses-search {
+  &.--is-desktop {
+    .v-input__slot {
+      box-shadow: none !important;
+      border: 1px solid $light-gray;
+    }
+  }
+
+  .v-text-field__details {
+    display: none;
+  }
+}
+
+.detail-responses {
+  &__info {
+    .title {
+      @include font-size(1.5);
+    }
+
+    .description {
+      @include font-size(1);
+    }
+  }
+}
+</style>

--- a/ui/src/views/user/survey-detail/components/DetailSummary.vue
+++ b/ui/src/views/user/survey-detail/components/DetailSummary.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="detail-summary">
+    detail summary
+  </div>
+</template>
+
+<script>
+export default { name: "DetailSummary" };
+</script>

--- a/ui/src/views/user/survey-detail/components/DetailSummary.vue
+++ b/ui/src/views/user/survey-detail/components/DetailSummary.vue
@@ -1,9 +1,55 @@
 <template>
-  <div class="detail-summary">
-    detail summary
-  </div>
+  <v-container
+    fluid
+    tag="section"
+    class="fill-height detail-summary"
+  >
+    <v-row>
+      <v-col cols="12">
+        <vue-friendly-iframe
+          :src="summaryUrl"
+          @load="onLoadSummaryPage"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>
-export default { name: "DetailSummary" };
+export default {
+  name: "DetailSummary",
+  data() {
+    return {
+      summaryUrl: "http://localhost:8080/",
+    };
+  },
+  created() {
+    this.getSurveySummary();
+  },
+  computed: {
+    surveyId() {
+      return this.$route.params.id;
+    },
+  },
+  methods: {
+    onLoadSummaryPage() {
+      // do something
+    },
+    getSurveySummary() {
+      // get survey summary by id
+      // assign to summaryUrl
+      // load
+    },
+  },
+};
 </script>
+<style lang="scss">
+.detail-summary {
+  .vue-friendly-iframe {
+    iframe {
+      width: 100%;
+      min-height: 100vh;
+    }
+  }
+}
+</style>

--- a/ui/src/views/user/survey-detail/components/DetailSummary.vue
+++ b/ui/src/views/user/survey-detail/components/DetailSummary.vue
@@ -48,7 +48,7 @@ export default {
   .vue-friendly-iframe {
     iframe {
       width: 100%;
-      min-height: 100vh;
+      min-height: 500px;
     }
   }
 }

--- a/ui/src/views/user/survey-detail/components/DetailSummary.vue
+++ b/ui/src/views/user/survey-detail/components/DetailSummary.vue
@@ -20,16 +20,16 @@ export default {
   name: "DetailSummary",
   data() {
     return {
-      summaryUrl: "http://localhost:8080/",
+      summaryUrl: "http://localhost:8080/"
     };
-  },
-  created() {
-    this.getSurveySummary();
   },
   computed: {
     surveyId() {
       return this.$route.params.id;
-    },
+    }
+  },
+  created() {
+    this.getSurveySummary();
   },
   methods: {
     onLoadSummaryPage() {
@@ -39,8 +39,8 @@ export default {
       // get survey summary by id
       // assign to summaryUrl
       // load
-    },
-  },
+    }
+  }
 };
 </script>
 <style lang="scss">

--- a/ui/src/views/user/survey-edit/components/SurveyPreview.vue
+++ b/ui/src/views/user/survey-edit/components/SurveyPreview.vue
@@ -23,7 +23,7 @@ import GenerateForm from "@/form-builder/components/GenerateForm.vue";
 export default {
   name: "SurveyPreview",
   components: {
-    GenerateForm
+    GenerateForm,
   },
   props: {
     value: {
@@ -32,15 +32,15 @@ export default {
         return {
           formBuilder: {
             list: [],
-            models: {}
-          }
+            models: {},
+          },
         };
-      }
-    }
+      },
+    },
   },
   data() {
     return {
-      generateFormKey: 1
+      generateFormKey: 1,
     };
   },
   watch: {
@@ -51,14 +51,9 @@ export default {
         this.$nextTick(() => {
           this.$forceUpdate();
         });
-      }
-    }
+      },
+    },
   },
-  methods: {
-    getData() {
-      console.log(JSON.stringify(this.value));
-    }
-  }
 };
 </script>
 

--- a/ui/src/views/user/survey-edit/components/SurveyPreview.vue
+++ b/ui/src/views/user/survey-edit/components/SurveyPreview.vue
@@ -23,7 +23,7 @@ import GenerateForm from "@/form-builder/components/GenerateForm.vue";
 export default {
   name: "SurveyPreview",
   components: {
-    GenerateForm,
+    GenerateForm
   },
   props: {
     value: {
@@ -32,15 +32,15 @@ export default {
         return {
           formBuilder: {
             list: [],
-            models: {},
-          },
+            models: {}
+          }
         };
-      },
-    },
+      }
+    }
   },
   data() {
     return {
-      generateFormKey: 1,
+      generateFormKey: 1
     };
   },
   watch: {
@@ -51,9 +51,9 @@ export default {
         this.$nextTick(() => {
           this.$forceUpdate();
         });
-      },
-    },
-  },
+      }
+    }
+  }
 };
 </script>
 

--- a/ui/src/views/user/survey-edit/components/SurveySettings.vue
+++ b/ui/src/views/user/survey-edit/components/SurveySettings.vue
@@ -5,8 +5,8 @@
     class="survey-settings"
   >
     <v-row
-      justify="start"
       v-if="canSetDate"
+      justify="start"
     >
       <v-col
         cols="12"
@@ -144,8 +144,8 @@
           class="survey-link mt-5"
           @click="copyLinkToClipboard"
         >
-          <a :href="survey.data.link">
-            {{ survey.data.link || 'An error occured' }}
+          <a :href="surveyLink">
+            {{ surveyLink || 'An error occured' }}
           </a>
           <v-icon>mdi-content-copy</v-icon>
         </div>
@@ -302,24 +302,22 @@ export default {
   props: {
     canSetDate: {
       type: Boolean,
-      default: true,
+      default: true
     },
     survey: {
       type: Object,
       default() {
         return {
-          data: {
-            link: "http://www.google.com",
-          },
+          data: {}
         };
-      },
+      }
     },
     value: {
       type: Object,
       default() {
         return {};
-      },
-    },
+      }
+    }
   },
   data() {
     return {
@@ -327,23 +325,32 @@ export default {
       isEndDateMenuShown: false,
       // eslint-disable-next-line no-undef
       todayDate: moment().format("YYYY-MM-DD"),
+      baseUrl: window.location.origin,
       newEmail: "",
       formData: {
         startDate: "",
         endDate: "",
         isPublic: true,
         emails: [],
-        isSurveySentAutomatically: false,
-      },
+        isSurveySentAutomatically: false
+      }
     };
+  },
+  computed: {
+    surveyId() {
+      return this.$route.params.id;
+    },
+    surveyLink() {
+      return `${this.baseUrl}/survey/${this.surveyId}`;
+    }
   },
   watch: {
     formData: {
       deep: true,
       handler() {
         this.$emit("input", this.formData);
-      },
-    },
+      }
+    }
   },
   created() {
     // load survey data from props
@@ -364,7 +371,7 @@ export default {
       EventBus.$on("event:getFormBuilderData", () => {
         EventBus.$emit("event:setFormBuilderData", {
           data: this.formData,
-          key: "config",
+          key: "config"
         });
       });
     },
@@ -373,7 +380,7 @@ export default {
       this.$notify.toast("Invitations have been sent");
     },
     copyLinkToClipboard() {
-      let isCopySuccessful = copyText(this.survey.data.link);
+      let isCopySuccessful = copyText(this.surveyLink);
       if (isCopySuccessful) {
         this.$notify.toast("Link has been copied to clipboard");
       }
@@ -387,8 +394,8 @@ export default {
     },
     getData() {
       return this.formData;
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/ui/src/views/user/survey-edit/components/SurveySettings.vue
+++ b/ui/src/views/user/survey-edit/components/SurveySettings.vue
@@ -4,7 +4,10 @@
     tag="section"
     class="survey-settings"
   >
-    <v-row justify="start">
+    <v-row
+      justify="start"
+      v-if="canSetDate"
+    >
       <v-col
         cols="12"
         class="text-left"
@@ -141,8 +144,8 @@
           class="survey-link mt-5"
           @click="copyLinkToClipboard"
         >
-          <a :href="survey.link">
-            {{ survey.link || 'An error occured' }}
+          <a :href="survey.data.link">
+            {{ survey.data.link || 'An error occured' }}
           </a>
           <v-icon>mdi-content-copy</v-icon>
         </div>
@@ -297,20 +300,26 @@ import { EventBus } from "@/util/event-bus";
 export default {
   name: "SurveySettings",
   props: {
+    canSetDate: {
+      type: Boolean,
+      default: true,
+    },
     survey: {
       type: Object,
       default() {
         return {
-          link: "http://www.google.com"
+          data: {
+            link: "http://www.google.com",
+          },
         };
-      }
+      },
     },
     value: {
       type: Object,
       default() {
         return {};
-      }
-    }
+      },
+    },
   },
   data() {
     return {
@@ -324,8 +333,8 @@ export default {
         endDate: "",
         isPublic: true,
         emails: [],
-        isSurveySentAutomatically: false
-      }
+        isSurveySentAutomatically: false,
+      },
     };
   },
   watch: {
@@ -333,8 +342,12 @@ export default {
       deep: true,
       handler() {
         this.$emit("input", this.formData);
-      }
-    }
+      },
+    },
+  },
+  created() {
+    // load survey data from props
+    // map to form data
   },
   mounted() {
     this.$emit("input", this.formData);
@@ -351,15 +364,16 @@ export default {
       EventBus.$on("event:getFormBuilderData", () => {
         EventBus.$emit("event:setFormBuilderData", {
           data: this.formData,
-          key: "config"
+          key: "config",
         });
       });
     },
     onSendInvitationButtonClick() {
       console.log("send invitation");
+      this.$notify.toast("Invitations have been sent");
     },
     copyLinkToClipboard() {
-      let isCopySuccessful = copyText(this.survey.link);
+      let isCopySuccessful = copyText(this.survey.data.link);
       if (isCopySuccessful) {
         this.$notify.toast("Link has been copied to clipboard");
       }
@@ -373,8 +387,8 @@ export default {
     },
     getData() {
       return this.formData;
-    }
-  }
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
## Survey detail 
### What's new
- ui/src/views/user/survey-detail/components/* : components for survey detail page
- ui/src/plugins/vuetify-friendly-iframe.js: a new plugin to load iframe from dynamic url

### What's changed
- ui/package.json: added a new package to help loading iframe from dynamic url 
- ui/src/assets/json/survey-data-sample.json: updated the json sample file
- ui/src/components/BottomSheet.vue: refactored a bit; emitted an event called 'close' when clicking the close button
- ui/src/components/ContentCard.vue: modified the styling a bit; including the !important property in the mixins
- ui/src/form-builder/components/GenerateForm.vue: added props to disable form item and to show/hide submit button
- ui/src/form-builder/components/GenerateFormItem.vue: added new prop to disable form item
- ui/src/views/user/survey-edit/components/SurveySettings.vue: added new prop to show/hide date editing
- ui/src/views/user/signup-thankyou/SignupThankyouView.vue: tidied a bit
- ui/src/plugins/index.js: imported a new plugin, vuetify-friendly-iframe
- ui/src/styles/mixins/_typography.scss: added a new property to the font-size mixin; now we can set the importance of the newly set font-size
- ui/src/util/dates.js: added several date helpers
- ui/src/styles/variables.js: added a new color, "lightBlue"
- ui/src/views/general/privacy-policy/PrivacyPolicyView.vue: finished the privacy policy view 
- ui/src/views/general/terms-and-conditions/TermsAndConditionsView.vue: finished the terms and conditions view

### Notable
- the mobile design ended up a bit different (the tabs color is different) because I think the default one is good enough XD
- Instead of coding from scratch, now the summary will be loaded directly from url given by BE. Right now the summaryUrl is still using the localhost:8080/ link, which should be localhost:8000, yet cannot test it because I still got problems with docker
- added a new property in the @font-size mixin to set the font size property (defaults to nothing). This is especially useful if we need to override the default font-size set by vuetify

### To do
- API implementation, axios setting
- validation on survey builder page


### Screenshots
#### Desktop
![image](https://user-images.githubusercontent.com/12537724/173457573-4e0eb222-896a-4df2-b6d4-e62d3232ace9.png)![image](https://user-images.githubusercontent.com/12537724/173460060-7b73a73b-3cd6-4b5d-9dff-35ffb1b90598.png)
![image](https://user-images.githubusercontent.com/12537724/173457708-87f76978-1aeb-491b-bc58-781ed96260b0.png)
![image](https://user-images.githubusercontent.com/12537724/173457768-5df0a009-d223-4f36-9e66-2412beb683e4.png)
![image](https://user-images.githubusercontent.com/12537724/173457807-84f44acf-6b50-46a9-9fb8-f9b81650c441.png)
![image](https://user-images.githubusercontent.com/12537724/173457831-8753375e-e0b6-422b-9a41-72cf1c1eb056.png)
![image](https://user-images.githubusercontent.com/12537724/173460638-f423191d-b344-4c74-b16f-f18e88eea48e.png)
![image](https://user-images.githubusercontent.com/12537724/173460663-3c7a7215-035b-45e5-aa14-4b2c31e8a3d5.png)
![image](https://user-images.githubusercontent.com/12537724/173577563-3b7617cc-a0dc-41a8-9570-7f7673bc87aa.png)


After datatable removal: 
![image](https://user-images.githubusercontent.com/12537724/173577529-6d38e71c-bd86-46c2-b164-5c6e7f4cddc8.png)




#### Mobile
![image](https://user-images.githubusercontent.com/12537724/173458583-235fb878-cf40-4efe-ad47-4a277420352d.png)
![image](https://user-images.githubusercontent.com/12537724/173458658-c6d39942-bf6a-4af2-894d-094e7ae83fb6.png)
![image](https://user-images.githubusercontent.com/12537724/173458688-b0222022-c61a-4208-b4d8-9c00a4ff11cb.png)
![image](https://user-images.githubusercontent.com/12537724/173460188-f3e366f9-50a1-4109-86a3-da7dbb5746ab.png)
![image](https://user-images.githubusercontent.com/12537724/173458767-fc619cdd-edf7-4c9e-892c-f64e48058a22.png)
![image](https://user-images.githubusercontent.com/12537724/173460767-a30caaf4-fe46-492e-a594-f78ebc0d52f5.png)
![image](https://user-images.githubusercontent.com/12537724/173460794-d1a0aea4-83fa-4d9e-afde-5f75ba2d5e6d.png)



