### PR TITLE
feat: added cookies confirmation, standardized toast on api error

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -8,6 +8,7 @@
 
 <script>
 import "@/styles/overrides.scss";
+import { EventBus } from "@util/event-bus";
 
 export default {
   name: "App",
@@ -19,6 +20,14 @@ export default {
       { charset: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" }
     ]
+  },
+  mounted() {
+    EventBus.$on("event:apiError", () => {
+      this.$notify.toast("Something went wrong. Please try again later.");
+    });
+  },
+  beforeDestroy() {
+    EventBus.$off("event:apiError");
   }
 };
 </script>

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -1,11 +1,11 @@
 import config from "./config.js";
+import { EventBus } from "@util/event-bus";
 
 const axios = require("axios");
 
 const { timeout, baseURL } = config;
 axios.defaults.baseURL = baseURL;
 axios.defaults.timeout = timeout;
-
 axios.defaults.headers.common["Accept"] = "application/json";
 axios.defaults.headers.common["Content-Type"] = "application/json";
 
@@ -16,6 +16,7 @@ axios.interceptors.request.use(
   },
   (error) => {
     console.log("API Request Error:", error);
+    EventBus.$emit("event:apiError", error);
     return Promise.reject(new Error(error).message);
   }
 );
@@ -27,12 +28,15 @@ axios.interceptors.response.use(
   },
   (error) => {
     console.log("API Response Error:", error);
+    EventBus.$emit("event:apiError", error);
     return Promise.reject(new Error(error).message);
   }
 );
 
 const GET_SURVEYS_URL = "user/surveys";
 const ADD_SURVEY_URL = "user/surveys";
+const USER_LOGIN_URL = "authentication/login";
+const USER_SIGNUP_URL = "authentication/signup";
 
 export const getSurveys = () => {
   return axios.get(GET_SURVEYS_URL);
@@ -42,14 +46,10 @@ export const addSurvey = (data) => {
   return axios.post(ADD_SURVEY_URL, data);
 };
 
-const USER_SIGNUP_URL = "authentication/signup";
-
 export const userSignup = (data) => {
   return axios.post(USER_SIGNUP_URL, data);
-}
-
-const USER_LOGIN_URL = "authentication/login";
+};
 
 export const userLogin = (data) => {
   return axios.post(USER_LOGIN_URL, data, config);
-}
+};

--- a/ui/src/components/BottomSheet.vue
+++ b/ui/src/components/BottomSheet.vue
@@ -1,14 +1,14 @@
 <template>
   <v-bottom-sheet
     v-model="show"
-    persistent
+    :persistent="persistent"
     :attach="fullscreen"
     :fullscreen="fullscreen"
     class="bottom-sheet s-bottom-sheet"
   >
     <v-sheet
       class="text-center s-bottom-sheet__content"
-      :height="windowHeight-distance"
+      :height="height || windowHeight-distance"
     >
       <v-container>
         <v-row
@@ -56,9 +56,17 @@ export default {
       type: String,
       default: ""
     },
+    height: {
+      type: Number,
+      default: 0
+    },
     distance: {
       type: Number,
       default: 100
+    },
+    persistent: {
+      type: Boolean,
+      default: false
     },
     fullscreen: {
       type: Boolean,
@@ -84,6 +92,16 @@ export default {
 };
 </script>
 <style lang="scss">
+// bottom-sheet
+.v-bottom-sheet {
+  &:not(.v-dialog--fullscreen) {
+    .v-sheet {
+      border-top-left-radius: 20px !important;
+      border-top-right-radius: 20px !important;
+    }
+  }
+}
+
 .s-bottom-sheet {
   &__content {
     height: 100vh !important;

--- a/ui/src/components/BottomSheet.vue
+++ b/ui/src/components/BottomSheet.vue
@@ -50,28 +50,28 @@ export default {
     value: Boolean,
     alignTitle: {
       type: String,
-      default: "left"
+      default: "left",
     },
     title: {
       type: String,
-      default: ""
+      default: "",
     },
     height: {
       type: Number,
-      default: 0
+      default: 0,
     },
     distance: {
       type: Number,
-      default: 100
+      default: 100,
     },
     persistent: {
       type: Boolean,
-      default: false
+      default: true,
     },
     fullscreen: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
   computed: {
     show: {
@@ -80,15 +80,15 @@ export default {
       },
       set(value) {
         this.$emit("input", value);
-      }
-    }
+      },
+    },
   },
   methods: {
     onClickCloseButton() {
       this.show = !this.show;
       this.$emit("close");
-    }
-  }
+    },
+  },
 };
 </script>
 <style lang="scss">

--- a/ui/src/layouts/default/CookiesConfirmation.vue
+++ b/ui/src/layouts/default/CookiesConfirmation.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-bottom-sheet
+    v-model="show"
+    persistent
+    attach
+    class="cookies-confirmation"
+  >
+    <v-card
+      class="text-center cookies-confirmation__card"
+      elevation="2"
+    >
+      <v-container>
+        <v-row
+          class="mt-6 text-center"
+          justify="center"
+          align="center"
+        >
+          <v-col
+            cols="12"
+            class="py-0"
+          >
+            <h2>Cookie Policy</h2>
+          </v-col>
+          <v-col
+            cols="12"
+            class="mb-5"
+          >
+            <p>Please accept the usage of cookies to continue using our website.</p>
+            <v-btn
+              text
+              outlined
+              @click="onClickAcceptButton"
+            >
+              Accept
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-bottom-sheet>
+</template>
+
+<script>
+export default {
+  name: "CookiesConfirmation",
+  props: {
+    value: Boolean
+  },
+  computed: {
+    show: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit("input", value);
+      }
+    }
+  },
+  methods: {
+    onClickAcceptButton() {
+      this.show = false;
+      this.$emit("accept", true);
+    }
+  }
+};
+</script>

--- a/ui/src/layouts/default/Footer.vue
+++ b/ui/src/layouts/default/Footer.vue
@@ -33,7 +33,7 @@ export default {
   components: { Links, CookiesConfirmation },
   data() {
     return {
-      isCookiesBottomSheetShown: false
+      isCookiesBottomSheetShown: false,
     };
   },
   computed: {
@@ -46,20 +46,14 @@ export default {
       },
       set(val) {
         this.$store.dispatch("user/setHasAcceptedCookies", val);
-      }
-    }
+      },
+    },
   },
   mounted() {
     if (!this.hasAcceptedCookies) {
       this.isCookiesBottomSheetShown = true;
     }
   },
-  methods: {
-    onClickAcceptButton() {
-      this.isCookiesBottomSheetShown = false;
-      this.hasAcceptedCookies = true;
-    }
-  }
 };
 </script>
 

--- a/ui/src/layouts/default/Footer.vue
+++ b/ui/src/layouts/default/Footer.vue
@@ -1,33 +1,63 @@
 <template>
-  <v-footer
-    id="default-footer"
-    class="default-footer"
-    :color="style.color.primary"
-  >
-    <div class="default-footer__copyright">
-      <v-img
-        :src="logo"
-        max-height="48"
-        max-width="48"
-      />
-      <span class="copyright">
-        (c) {{ new Date().getFullYear() }} SurveyApp Team
-      </span>
-    </div>
-    <links class="default-footer__links" />
-  </v-footer>
+  <div>
+    <cookies-confirmation
+      v-model="isCookiesBottomSheetShown"
+      @accept="hasAcceptedCookies = true"
+    />
+    <v-footer
+      id="default-footer"
+      class="default-footer"
+      :color="style.color.primary"
+    >
+      <div class="default-footer__copyright">
+        <v-img
+          :src="logo"
+          max-height="48"
+          max-width="48"
+        />
+        <span class="copyright">
+          (c) {{ new Date().getFullYear() }} SurveyApp Team
+        </span>
+      </div>
+      <links class="default-footer__links" />
+    </v-footer>
+  </div>
 </template>
 
 <script>
-// Components
 import Links from "@/components/Links";
+import CookiesConfirmation from "./CookiesConfirmation.vue";
 
 export default {
   name: "DefaultFooter",
-  components: { Links },
+  components: { Links, CookiesConfirmation },
+  data() {
+    return {
+      isCookiesBottomSheetShown: false
+    };
+  },
   computed: {
     logo() {
       return require("@assets/svg/logo.svg");
+    },
+    hasAcceptedCookies: {
+      get() {
+        return this.$store.getters["user/hasAcceptedCookies"];
+      },
+      set(val) {
+        this.$store.dispatch("user/setHasAcceptedCookies", val);
+      }
+    }
+  },
+  mounted() {
+    if (!this.hasAcceptedCookies) {
+      this.isCookiesBottomSheetShown = true;
+    }
+  },
+  methods: {
+    onClickAcceptButton() {
+      this.isCookiesBottomSheetShown = false;
+      this.hasAcceptedCookies = true;
     }
   }
 };

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -212,7 +212,7 @@ router.beforeEach((to, from, next) => {
       store.dispatch("user/setUserData", {});
       store.dispatch("user/setToken", "");
       store.dispatch("user/setItems", []);
-      Cookies.remove("user");
+      Cookies.remove("access_token_cookie");
 
       return next({ name: "general-landing" });
     } else if (shouldBePrevented(to.name)) {

--- a/ui/src/store/index.js
+++ b/ui/src/store/index.js
@@ -2,8 +2,6 @@ import Vue from "vue";
 import Vuex from "vuex";
 import VuexPersistence from "vuex-persist";
 import pathify from "@/plugins/vuex-pathify";
-import Cookies from "js-cookie";
-
 
 // Modules
 import * as modules from "./modules";
@@ -12,28 +10,15 @@ Vue.use(Vuex);
 
 const vuexLocal = new VuexPersistence({
   storage: window.localStorage,
-  reducer: (state) => ({ app: state.app })
-});
-
-const vuexCookie = new VuexPersistence({
-  restoreState: (key) => Cookies.get(key) ? JSON.parse(Cookies.get(key)) : {},
-  saveState: (key, state) =>
-    Cookies.set(key, JSON.stringify(state), {
-      expires: 3
-    }),
-  modules: [ "user" ] //only save user module
+  reducer: (state) => ({ app: state.app, user: state.user }) // unsafe
 });
 
 const store = new Vuex.Store({
   modules,
-  plugins: [
-    pathify.plugin,
-    vuexLocal.plugin,
-    vuexCookie.plugin
-  ]
+  plugins: [ pathify.plugin, vuexLocal.plugin ]
 });
 
-store.subscribe(mutation => {
+store.subscribe((mutation) => {
   if (!mutation.type.startsWith("user/")) return;
 });
 

--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -44,14 +44,12 @@ const generalMenuItems = [
 const state = {
   userData: {
     accountType: null,
-    email: null,
-    hasAcceptedPrivacyPolicy: false,
-    hasAcceptedTnC: false
+    email: null
   },
   token: null,
-  drawer: {
-    mini: false
-  },
+  hasAcceptedCookies: false,
+  hasAcceptedPrivacyPolicy: false,
+  hasAcceptedTnC: false,
   items: generalMenuItems
 };
 
@@ -59,12 +57,6 @@ const mutations = {
   ...make.mutations(state),
   setUserData(state, data) {
     state.userData = { ...state.userData, ...data };
-  },
-  setUserDataPrivacyPolicy(state, data) {
-    state.userData.hasAcceptedPrivacyPolicy = data;
-  },
-  setUserDataTnC(state, data) {
-    state.userData.hasAcceptedTnC = data;
   }
 };
 
@@ -88,18 +80,6 @@ const actions = {
     } else if (state.userData.accountType == 1) {
       dispatch("setItems", adminMenuItems.concat(generalMenuItems));
     }
-  },
-  setUserDataPrivacyPolicy: ({ state, dispatch }, data) => {
-    dispatch("setUserData", {
-      ...state.userData,
-      ...{ hasAcceptedPrivacyPolicy: data }
-    });
-  },
-  setUserDataTnC: ({ state, dispatch }, data) => {
-    dispatch("setUserData", {
-      ...state.userData,
-      ...{ hasAcceptedTnC: data }
-    });
   }
 };
 
@@ -108,10 +88,13 @@ const getters = {
     return !!state.token;
   },
   hasAcceptedPrivacyPolicy: (state) => {
-    return !!state.userData.hasAcceptedPrivacyPolicy;
+    return !!state.hasAcceptedPrivacyPolicy;
   },
   hasAcceptedTnC: (state) => {
-    return !!state.userData.hasAcceptedTnC;
+    return !!state.hasAcceptedTnC;
+  },
+  hasAcceptedCookies: (state) => {
+    return !!state.hasAcceptedCookies;
   },
   userData: (state) => {
     return state.userData || {};

--- a/ui/src/styles/overrides.scss
+++ b/ui/src/styles/overrides.scss
@@ -82,15 +82,6 @@ table {
   }
 }
 
-// bottom-sheet
-.v-bottom-sheet {
-  &:not(.v-dialog--fullscreen) {
-    .v-sheet {
-      border-top-left-radius: 20px !important;
-      border-top-right-radius: 20px !important;
-    }
-  }
-}
 
 // display flex
 .justify-flex--end {

--- a/ui/src/views/user/login/LoginView.vue
+++ b/ui/src/views/user/login/LoginView.vue
@@ -108,8 +108,8 @@ export default {
       isPasswordShown: false,
       formData: {
         email: "",
-        password: ""
-      }
+        password: "",
+      },
     };
   },
   methods: {
@@ -120,15 +120,16 @@ export default {
       // save to vuex
       const userData = {
         accountType: 0,
-        email: "user@email.com"
+        email: "user@email.com",
       };
+      // this.$cookies.set("access_token_cookie", "test");  // can be set if needed, token is already set in vuex tho
       this.$store.dispatch("user/setToken", "test");
       this.$store.dispatch("user/setUserData", userData);
       this.$store.dispatch("user/checkAccountTypeAndSetMenuItems");
 
       this.$router.push({ name: "user-surveys" });
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/ui/src/views/user/login/LoginView.vue
+++ b/ui/src/views/user/login/LoginView.vue
@@ -120,9 +120,7 @@ export default {
       // save to vuex
       const userData = {
         accountType: 0,
-        email: "user@email.com",
-        hasAcceptedPrivacyPolicy: false,
-        hasAcceptedTnC: false
+        email: "user@email.com"
       };
       this.$store.dispatch("user/setToken", "test");
       this.$store.dispatch("user/setUserData", userData);

--- a/ui/src/views/user/settings/SettingsView.vue
+++ b/ui/src/views/user/settings/SettingsView.vue
@@ -132,20 +132,20 @@ export default {
       isPasswordShown: false,
       formData: {
         email: "",
-        password: ""
+        password: "",
       },
       isDeleteItemModalShown: false,
-      isSucessSnackbarShown: false
+      isSucessSnackbarShown: false,
     };
   },
   computed: {
-    ...mapGetters("user", [ "userData" ]),
+    ...mapGetters("user", ["userData"]),
     userEmail() {
       return this.userData.email;
     },
     isPasswordLengthOkay() {
       return this.formData.password.length >= 8;
-    }
+    },
   },
   methods: {
     onFormSubmit() {
@@ -161,13 +161,13 @@ export default {
       this.$store.dispatch("user/setToken", "");
       this.$store.dispatch("user/setUserData", {});
       this.$store.dispatch("user/setItems", []);
-      this.$cookies.remove("user");
+      this.$cookies.remove("access_token_cookie");
 
       this.$router
         .push({ name: "general-user-delete-thankyou" })
         .catch(() => {});
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/ui/src/views/user/signup/SignupView.vue
+++ b/ui/src/views/user/signup/SignupView.vue
@@ -114,21 +114,15 @@ export default {
   },
   methods: {
     onFormSubmit() {
-      userSignup(this.formData)
-        .then((response) => {
-          if (response["message"].includes(" already exists.")) {
-            this.$notify.toast(response["message"]);
-          }
-          else {
-            this.$router
-              .push({ name: "general-user-signup-thankyou" })
-              .catch(() => {});
-          }
-        })
-        .catch((error) => {
-          this.$notify.toast("Something went wrong. Please try again later.");
-          console.log(error);
-        });
+      userSignup(this.formData).then((response) => {
+        if (response["message"].includes(" already exists.")) {
+          this.$notify.toast(response["message"]);
+        } else {
+          this.$router
+            .push({ name: "general-user-signup-thankyou" })
+            .catch(() => {});
+        }
+      });
     }
   }
 };

--- a/ui/src/views/user/surveys/SurveysView.vue
+++ b/ui/src/views/user/surveys/SurveysView.vue
@@ -388,9 +388,7 @@ export default {
     ...sync("app", [ "mini" ]),
     ...mapGetters("user", [ "hasAcceptedPrivacyPolicy", "hasAcceptedTnC" ]),
     hasAcceptedConditions() {
-      return (
-        this.userData.hasAcceptedPrivacyPolicy && this.userData.hasAcceptedTnC
-      );
+      return this.hasAcceptedPrivacyPolicy && this.hasAcceptedTnC;
     },
     filteredSurveys() {
       let surveys = this.keyword
@@ -477,7 +475,7 @@ export default {
       // call api to confirm privacy policy
       // set vuex
       this.$store.dispatch(
-        "user/setUserDataPrivacyPolicy",
+        "user/setHasAcceptedPrivacyPolicy",
         isPrivacyPolicyConfirmed
       );
       this.isPrivacyPolicyModalShown = false;
@@ -485,7 +483,7 @@ export default {
     onConfirmTnC(isTncConfirmed) {
       // call api to confirm privacy policy
       // set vuex
-      this.$store.dispatch("user/setUserDataTnC", isTncConfirmed);
+      this.$store.dispatch("user/setHasAcceptedTnC", isTncConfirmed);
       this.isTnCModalShown = false;
     },
     getSurveyApi() {


### PR DESCRIPTION
## Cookies Policy
Related to non-functional requirement NR0.4. "A user should be able to specifically accept having running cookies that are necessary for the functioning of the website."

### What's new: 
- ui/src/layouts/default/CookiesConfirmation.vue: confirmation dialog to confirm cookies. No option to reject, only accept. Values will be stored in vuex so user wont be asked twice. 

### What's changed: 
- ui/src/App.vue: added EventBus listener to trigger $notify.toast function on api error
- ui/src/api/index.js: imported EventBus to emit events on api error
- ui/src/components/BottomSheet.vue: added additional props, moved the bottom sheet styling here
- ui/src/layouts/default/Footer.vue: loaded the cookies confirmation component. Loaded it here instead of in App.vue because vuetify will returns error when 2 floating (?) elements (transition, bottom-sheet) is put within each other. 
- ui/src/store/index.js: refactored; moved the user data back to localStorage, refactored the code because its clear that BE wont store the hasAcceptedPrivacyPolicy and Tnc now, so I moved the values outside the userData so that it wont get cleared on logout. 
- ui/src/styles/overrides.scss: moved the bottom sheet styling from here to BottomSheet.vue
- ui/src/views/user/signup/SignupView.vue: removed the error catch block
- ui/src/views/user/surveys/SurveysView.vue, ui/src/views/user/login/LoginView.vue: changed how the system access the hasAcceptedPrivacyPolicy  after refactor

### Notable: 
- Generalized the error messages on api error with axios.interceptor

### To do: 
- API implementation
- UI testing set up

### Screenshots: 
![image](https://user-images.githubusercontent.com/12537724/173699828-32efecd1-1704-4bb9-a1f0-20c751b7e503.png)
![image](https://user-images.githubusercontent.com/12537724/173699796-f6f4a038-e5b1-43dd-abf3-7b2d5a49be17.png)


Cc @Daedheldir 

