### PR TITLE
fix: changed JWT_TOKEN_LOCATION to headers

### DIFF
--- a/api/common/settings.py
+++ b/api/common/settings.py
@@ -14,5 +14,7 @@ JWT_BLACKLIST_TOKEN_CHECKS = ['access', 'refresh']
 # If true this will only allow the cookies that contain your JWTs to be sent
 # over https. In production, this should always be set to True
 JWT_COOKIE_SECURE = False
-JWT_TOKEN_LOCATION = ['cookies']
+JWT_TOKEN_LOCATION = ['headers']
 JWT_COOKIE_CSRF_PROTECT = False
+JWT_HEADER_NAME = 'Authorization'
+JWT_HEADER_TYPE = ''


### PR DESCRIPTION
Setting JWT_TOKEN_LOCATION to 'cookies' only may cause issues because the cookie will fail to be set if the connection is cross-site and unsecured. Setting it to ['headers', 'cookies'] doesn't work because apparently it will still insist on trying to find the token in cookies. Checking token in headers only is a confirmed solution that allows UI to call the protected API functions.

Also, I would like to request a function similar to authentication/NotActivated, but for checking the "isBlocked" status. 😅 