### PR TITLE
feat: implemented api calls user Login, user NotActivated, user ResendActivation

### DIFF
--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -1,9 +1,10 @@
 import config from "./config.js";
 import { EventBus } from "@util/event-bus";
+import Cookies from "js-cookie";
 
 const axios = require("axios");
-
 const { timeout, baseURL } = config;
+
 axios.defaults.baseURL = baseURL;
 axios.defaults.timeout = timeout;
 axios.defaults.headers.common["Accept"] = "application/json";
@@ -12,6 +13,10 @@ axios.defaults.headers.common["Content-Type"] = "application/json";
 // handle default
 axios.interceptors.request.use(
   (config) => {
+    const userToken = Cookies.get("access_token_cookie");
+    if (userToken) {
+      config.headers.Authorization = `Bearer ${userToken}`;
+    }
     return config;
   },
   (error) => {
@@ -35,8 +40,10 @@ axios.interceptors.response.use(
 
 const GET_SURVEYS_URL = "user/surveys";
 const ADD_SURVEY_URL = "user/surveys";
-const USER_LOGIN_URL = "authentication/login";
 const USER_SIGNUP_URL = "authentication/signup";
+const USER_LOGIN_URL = "authentication/login";
+const USER_NOT_ACTIVATED_URL = "authentication/notactivated";
+const USER_RESEND_ACTIVATION_URL = "authentication/resend";
 
 export const getSurveys = () => {
   return axios.get(GET_SURVEYS_URL);
@@ -51,5 +58,13 @@ export const userSignup = (data) => {
 };
 
 export const userLogin = (data) => {
-  return axios.post(USER_LOGIN_URL, data, config);
+  return axios.post(USER_LOGIN_URL, data);
 };
+
+export const userNotActivated = () => {
+  return axios.get(USER_NOT_ACTIVATED_URL);
+}
+
+export const userResendActivation = () => {
+  return axios.post(USER_RESEND_ACTIVATION_URL);
+}

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -41,6 +41,14 @@ const userRoutes = [
         import(
           /* webpackChunkName: "user-settings" */ "@views/user/settings/SettingsView.vue"
         )
+    },
+    {
+      path: "/user/confirm",
+      name: "user-confirm",
+      component: () =>
+        import(
+          /* webpackChunkName: "user-confirm" */ "@views/user/login-confirm/LoginConfirmView.vue"
+        )
     }
   ])
 ];
@@ -107,15 +115,6 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-user-login" */ "@views/user/login/LoginView.vue"
-        )
-    },
-    {
-      path: "/user/login/confirm",
-      meta: { isAccessableAfterLogin: false },
-      name: "general-user-login-confirm",
-      component: () =>
-        import(
-          /* webpackChunkName: "general-user-login-confirm" */ "@views/user/login-confirm/LoginConfirmView.vue"
         )
     },
     {
@@ -193,6 +192,7 @@ const router = new Router({
 router.beforeEach((to, from, next) => {
   const hasLoggedIn = store.getters["user/hasLoggedIn"];
   const accountType = store.getters["user/accountType"];
+  const hasBeenActivated = store.getters["user/hasBeenActivated"];
 
   const userMainPage = { name: "user-surveys" };
   const adminMainPage = { name: "admin-users" };
@@ -215,6 +215,8 @@ router.beforeEach((to, from, next) => {
       Cookies.remove("access_token_cookie");
 
       return next({ name: "general-landing" });
+    } else if (from.name == "user-confirm" && !hasBeenActivated) {
+      return next({ name: "user-confirm" });
     } else if (shouldBePrevented(to.name)) {
       if (accountType == 0) {
         return next(userMainPage);

--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -47,6 +47,7 @@ const state = {
     email: null
   },
   token: null,
+  hasBeenActivated: false,
   hasAcceptedCookies: false,
   hasAcceptedPrivacyPolicy: false,
   hasAcceptedTnC: false,
@@ -86,6 +87,9 @@ const actions = {
 const getters = {
   hasLoggedIn: (state) => {
     return !!state.token;
+  },
+  hasBeenActivated: (state) => {
+    return !!state.hasBeenActivated;
   },
   hasAcceptedPrivacyPolicy: (state) => {
     return !!state.hasAcceptedPrivacyPolicy;

--- a/ui/src/views/user/login-confirm/LoginConfirmView.vue
+++ b/ui/src/views/user/login-confirm/LoginConfirmView.vue
@@ -12,7 +12,7 @@
           :image="require('@assets/svg/man-woman-holding-mail.svg')"
           :max-image-height="isMobile ? 145: 305"
           :max-image-width="isMobile? 200: 400"
-          :showPrimaryButton="false"
+          :show-primary-button="false"
         >
           <template #actions>
             <div class="mt-5 text-secondary">

--- a/ui/src/views/user/login-confirm/LoginConfirmView.vue
+++ b/ui/src/views/user/login-confirm/LoginConfirmView.vue
@@ -12,7 +12,20 @@
           :image="require('@assets/svg/man-woman-holding-mail.svg')"
           :max-image-height="isMobile ? 145: 305"
           :max-image-width="isMobile? 200: 400"
-        />
+          :showPrimaryButton="false"
+        >
+          <template #actions>
+            <div class="mt-5 text-secondary">
+              Haven't received your activation email?
+              <v-btn
+                text
+                class="text-none pa-0 text-secondary "
+              >
+                <u class="d-inline-block ">Click here</u>
+              </v-btn>
+            </div>
+          </template>
+        </content-card>
       </v-col>
     </v-row>
   </v-container>

--- a/ui/src/views/user/login-confirm/LoginConfirmView.vue
+++ b/ui/src/views/user/login-confirm/LoginConfirmView.vue
@@ -8,7 +8,7 @@
       <v-col :cols="isMobile? 12 : 10">
         <content-card
           title="Your account hasn't been activated"
-          description="Please confirm your registration before using our services."
+          description="Please confirm your registration before using our services. After clicking the activation link, please logout and then re-login."
           :image="require('@assets/svg/man-woman-holding-mail.svg')"
           :max-image-height="isMobile ? 145: 305"
           :max-image-width="isMobile? 200: 400"
@@ -20,6 +20,7 @@
               <v-btn
                 text
                 class="text-none pa-0 text-secondary "
+                @click="onClickResendActivation"
               >
                 <u class="d-inline-block ">Click here</u>
               </v-btn>
@@ -32,7 +33,18 @@
 </template>
 
 <script>
-export default { name: "LoginConfirmView" };
+import { userResendActivation } from "@api";
+
+export default {
+  name: "LoginConfirmView",
+  methods: {
+    onClickResendActivation() {
+      userResendActivation().then((response) => {
+        this.$notify.toast(response["message"]);
+      });
+    }
+  }
+};
 </script>
 
 <style lang="scss">

--- a/ui/src/views/user/signup-thankyou/SignupThankyouView.vue
+++ b/ui/src/views/user/signup-thankyou/SignupThankyouView.vue
@@ -10,19 +10,7 @@
           title="Thanks for registering!"
           description="Please check your inbox or spams to confirm your registration"
           :image="require('@assets/svg/man-woman-holding-mail.svg')"
-        >
-          <template #actions>
-            <div class="mt-5 text-secondary">
-              Haven't received your email?
-              <v-btn
-                text
-                class="text-none pa-0 text-secondary "
-              >
-                <u class="d-inline-block ">Click here</u>
-              </v-btn>
-            </div>
-          </template>
-        </content-card>
+        />
       </v-col>
     </v-row>
   </v-container>


### PR DESCRIPTION
What's changed:
- ui\src\store\modules\user.js : Added `hasBeenActivated` and its getter.
- ui\src\router\index.js : (1) Renamed `general-user-login-confirm` into `user-confirm`, (2) Moved user-confirm to userRoutes, (3) Added routing check `else if (from.name == "user-confirm" && !hasBeenActivated)` to prevent a user who hasn't been activated from accessing other pages.
- ui\src\api\index.js : Added authorization header in the interceptor if userToken is set, added api functions for checking user isActivated and resending activation email.
- ui\src\views\user\login\LoginView.vue : Implemented login api call and checking user isActivated api call, adjusted router push based on if the user is activated or not.
- ui\src\views\user\signup-thankyou\SignupThankyouView.vue : Removed button for resending activation email, due to the fact that the BE api for resending activation email requires logging in first.
- ui\src\views\user\login-confirm\LoginConfirmView.vue : Added button for resending activation email, added the api call for resending the activation email.

Notable:
- I decided to use Cookie `access_token_cookie` because for me it is easier to use when checking userToken in axios interceptor.
- The page `user-confirm` is basically like a "traphole" in which the only action the user can do is to logout, or to resend activation link.

To Do:
Finish implementing all remaining api calls: update user account password, and then other 'utility' api calls like logout, admin actions, etc before going for the survey-related apis.

User Signup Thankyou:
<img width="960" alt="user-register-thanks" src="https://user-images.githubusercontent.com/64476430/173814984-f21e743b-2835-40de-add5-a7acfaf97f5a.png">

User Not Activated:
Note: The description of the content card now reads "Please confirm your registration before using our services. **After clicking the activation link, please logout and then re-login.**" (the extra sentence not shown in screenshot). The extra sentence is deemed necessary info to let the user know that they should click activation link, and then logout and re-login in order to be able to access other pages.
<img width="960" alt="user-not-activated" src="https://user-images.githubusercontent.com/64476430/173815006-01404bc0-b3a2-4f83-aec1-f9fce68bc10f.png">
