### PR TITLE
fix: added eslint-plugin-cypress

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,6 +41,7 @@
     "dotenv": "^16.0.1",
     "eslint": "^7.0.0",
     "eslint-loader": "^4.0.2",
+	"eslint-plugin-cypress": "^2.0.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",


### PR DESCRIPTION
As a solution to issue #41 , dependency `eslint-plugin-cypress` may need to be added to `package.json` to allow eslint to be familiar with cypress variables.

What's changed:
ui/package.json : Added "eslint-plugin-cypress": "^2.0.1"