### PR TITLE
feat: implemented API calls admin: login, logout, change pwd, user management actions

### DIFF
--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -59,7 +59,7 @@ const ADMIN_SEARCH_USER_URL = "admin/searchuser";
 const ADMIN_RESET_USER_PASSWORD_URL = "admin/resetuserpassword";
 const ADMIN_ACTIVATE_USER_URL = "admin/activateuser";
 const ADMIN_BLOCK_USER_URL = "admin/blockuser";
-const ADMIN_UNBLOCK_USER_URL = "admin/unblockuser";
+const ADMIN_UNBLOCK_USER_URL = "admin/unblockeduser";
 const ADMIN_DELETE_USER_URL = "admin/deleteuser";
 
 export const getSurveys = () => {

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -52,8 +52,8 @@ const USER_DELETE_ACCOUNT_URL = "user/delete";
 
 const ADMIN_LOGIN_URL = "admin/login";
 const ADMIN_LOGOUT_URL = "admin/logout";
-//const ADMIN_CHANGE_PASSWORD_URL = ;
-//const ADMIN_DELETE_SURVEY_URL = ;
+const ADMIN_CHANGE_PASSWORD_URL = "admin/changepassword";
+const ADMIN_DELETE_SURVEY_URL = "admin/deletesurvey";
 const ADMIN_LIST_USERS_URL = "admin/listusers";
 const ADMIN_SEARCH_USER_URL = "admin/searchuser";
 const ADMIN_RESET_USER_PASSWORD_URL = "admin/resetuserpassword";
@@ -84,19 +84,19 @@ export const userLogout = () => {
 
 export const userNotActivated = () => {
   return axios.get(USER_NOT_ACTIVATED_URL);
-}
+};
 
 export const userResendActivation = () => {
   return axios.post(USER_RESEND_ACTIVATION_URL);
-}
+};
 
 export const userChangePassword = (data) => {
   return axios.post(USER_CHANGE_PASSWORD_URL, data);
-}
+};
 
 export const userDeleteAccount = () => {
   return axios.delete(USER_DELETE_ACCOUNT_URL);
-}
+};
 
 export const adminLogin = (data) => {
   return axios.post(ADMIN_LOGIN_URL, data);
@@ -106,30 +106,38 @@ export const adminLogout = () => {
   return axios.post(ADMIN_LOGOUT_URL);
 };
 
+export const adminChangePassword = (data) => {
+  return axios.post(ADMIN_CHANGE_PASSWORD_URL, data);
+};
+
+export const adminDeleteSurvey = (data) => {
+  return axios.post(ADMIN_DELETE_SURVEY_URL, data);
+};
+
 export const adminListUsers = () => {
   return axios.get(ADMIN_LIST_USERS_URL);
-}
+};
 
 export const adminSearchUser = (data) => {
   return axios.post(ADMIN_SEARCH_USER_URL, data);
-}
+};
 
 export const adminResetUserPassword = (data) => {
   return axios.post(ADMIN_RESET_USER_PASSWORD_URL, data);
-}
+};
 
 export const adminActivateUser = (data) => {
   return axios.post(ADMIN_ACTIVATE_USER_URL, data);
-}
+};
 
 export const adminBlockUser = (data) => {
   return axios.post(ADMIN_BLOCK_USER_URL, data);
-}
+};
 
 export const adminUnblockUser = (data) => {
   return axios.post(ADMIN_UNBLOCK_USER_URL, data);
-}
+};
 
 export const adminDeleteUser = (data) => {
   return axios.post(ADMIN_DELETE_USER_URL, data);
-}
+};

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -54,6 +54,13 @@ const ADMIN_LOGIN_URL = "admin/login";
 const ADMIN_LOGOUT_URL = "admin/logout";
 //const ADMIN_CHANGE_PASSWORD_URL = ;
 //const ADMIN_DELETE_SURVEY_URL = ;
+const ADMIN_LIST_USERS_URL = "admin/listusers";
+const ADMIN_SEARCH_USER_URL = "admin/searchuser";
+const ADMIN_RESET_USER_PASSWORD_URL = "admin/resetuserpassword";
+const ADMIN_ACTIVATE_USER_URL = "admin/activateuser";
+const ADMIN_BLOCK_USER_URL = "admin/blockuser";
+const ADMIN_UNBLOCK_USER_URL = "admin/unblockuser";
+const ADMIN_DELETE_USER_URL = "admin/deleteuser";
 
 export const getSurveys = () => {
   return axios.get(GET_SURVEYS_URL);
@@ -77,19 +84,19 @@ export const userLogout = () => {
 
 export const userNotActivated = () => {
   return axios.get(USER_NOT_ACTIVATED_URL);
-};
+}
 
 export const userResendActivation = () => {
   return axios.post(USER_RESEND_ACTIVATION_URL);
-};
+}
 
 export const userChangePassword = (data) => {
   return axios.post(USER_CHANGE_PASSWORD_URL, data);
-};
+}
 
 export const userDeleteAccount = () => {
   return axios.delete(USER_DELETE_ACCOUNT_URL);
-};
+}
 
 export const adminLogin = (data) => {
   return axios.post(ADMIN_LOGIN_URL, data);
@@ -98,3 +105,31 @@ export const adminLogin = (data) => {
 export const adminLogout = () => {
   return axios.post(ADMIN_LOGOUT_URL);
 };
+
+export const adminListUsers = () => {
+  return axios.get(ADMIN_LIST_USERS_URL);
+}
+
+export const adminSearchUser = (data) => {
+  return axios.post(ADMIN_SEARCH_USER_URL, data);
+}
+
+export const adminResetUserPassword = (data) => {
+  return axios.post(ADMIN_RESET_USER_PASSWORD_URL, data);
+}
+
+export const adminActivateUser = (data) => {
+  return axios.post(ADMIN_ACTIVATE_USER_URL, data);
+}
+
+export const adminBlockUser = (data) => {
+  return axios.post(ADMIN_BLOCK_USER_URL, data);
+}
+
+export const adminUnblockUser = (data) => {
+  return axios.post(ADMIN_UNBLOCK_USER_URL, data);
+}
+
+export const adminDeleteUser = (data) => {
+  return axios.post(ADMIN_DELETE_USER_URL, data);
+}

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -17,7 +17,7 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-surveys" */ "@views/user/surveys/SurveysView.vue"
-        ),
+        )
     },
     {
       path: "/user/surveys/:id/edit",
@@ -25,7 +25,7 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-survey-edit" */ "@views/user/survey-edit/SurveyEditView.vue"
-        ),
+        )
     },
     {
       path: "/user/surveys/:id/",
@@ -33,7 +33,7 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-survey-detail" */ "@views/user/survey-detail/SurveyDetailView.vue"
-        ),
+        )
     },
     {
       path: "/user/settings",
@@ -41,7 +41,7 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-settings" */ "@views/user/settings/SettingsView.vue"
-        ),
+        )
     },
     {
       path: "/user/confirm",
@@ -49,9 +49,9 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-confirm" */ "@views/user/login-confirm/LoginConfirmView.vue"
-        ),
-    },
-  ]),
+        )
+    }
+  ])
 ];
 
 const adminRoutes = [
@@ -62,7 +62,7 @@ const adminRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "admin-surveys" */ "@views/admin/surveys/SurveysView.vue"
-        ),
+        )
     },
     {
       path: "/admin/users",
@@ -70,7 +70,7 @@ const adminRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "admin-users" */ "@views/admin/users/UsersView.vue"
-        ),
+        )
     },
     {
       path: "/admin/settings",
@@ -78,9 +78,9 @@ const adminRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "admin-settings" */ "@views/admin/settings/SettingsView.vue"
-        ),
-    },
-  ]),
+        )
+    }
+  ])
 ];
 
 const generalRoutes = [
@@ -91,7 +91,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-landing" */ "@views/general/landing/LandingView.vue"
-        ),
+        )
     },
     {
       path: "/privacy-policy",
@@ -99,7 +99,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-privacy-policy" */ "@views/general/privacy-policy/PrivacyPolicyView.vue"
-        ),
+        )
     },
     {
       path: "/terms-and-conditions",
@@ -107,7 +107,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-terms-and-conditions" */ "@views/general/terms-and-conditions/TermsAndConditionsView.vue"
-        ),
+        )
     },
     {
       path: "/user/login",
@@ -116,7 +116,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-user-login" */ "@views/user/login/LoginView.vue"
-        ),
+        )
     },
     {
       path: "/user/signup",
@@ -124,7 +124,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-user-signup" */ "@views/user/signup/SignupView.vue"
-        ),
+        )
     },
     {
       path: "/admin/login",
@@ -132,7 +132,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-admin-login" */ "@views/admin/login/LoginView.vue"
-        ),
+        )
     },
     {
       path: "/survey/:id",
@@ -140,7 +140,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-survey-fill" */ "@views/general/survey-fill/SurveyFillView.vue"
-        ),
+        )
     },
     {
       path: "/user/signup/thankyou",
@@ -148,7 +148,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-user-signup-thankyou" */ "@views/user/signup-thankyou/SignupThankyouView.vue"
-        ),
+        )
     },
     {
       path: "/user/delete/thankyou",
@@ -156,10 +156,10 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-user-delete-thankyou" */ "@views/user/delete-thankyou/DeleteThankyouView.vue"
-        ),
+        )
     },
-    { path: "/logout", name: "general-logout" },
-  ]),
+    { path: "/logout", name: "general-logout" }
+  ])
 ];
 
 const router = new Router({
@@ -177,9 +177,9 @@ const router = new Router({
     ...adminRoutes,
     layout("DefaultWithoutSidebar", [
       { path: "/404", name: "general-404", component: PageNotFoundView },
-      { path: "*", redirect: "404" },
-    ]),
-  ],
+      { path: "*", redirect: "404" }
+    ])
+  ]
 });
 
 router.beforeEach((to, from, next) => {
@@ -190,7 +190,7 @@ router.beforeEach((to, from, next) => {
   const userMainPage = { name: "user-surveys" };
   const adminMainPage = { name: "admin-users" };
 
-  const preventedWords = ["landing", "login", "signup", "delete"];
+  const preventedWords = [ "landing", "login", "signup", "delete" ];
   const shouldBePrevented = (routeName) => {
     return preventedWords.some((preventedWord) =>
       routeName.includes(preventedWord)

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -5,7 +5,7 @@ import { layout } from "@/util/routes";
 import PageNotFoundView from "@views/PageNotFoundView.vue";
 import store from "@store/index.js";
 import Cookies from "js-cookie";
-import { userLogout } from "@api";
+import { userLogout, adminLogout } from "@api";
 
 Vue.use(Router);
 
@@ -209,15 +209,27 @@ router.beforeEach((to, from, next) => {
 
   if (hasLoggedIn) {
     if (to.name == "general-logout") {
-      userLogout()
-        .then(() => {
-          unsetClientData();
-          return next({ name: "general-landing" });
-        })
-        .catch(() => {
-          unsetClientData();
-          return next({ name: "general-landing" });
-        });
+      if (accountType == 0) {
+        userLogout()
+          .then(() => {
+            unsetClientData();
+            return next({ name: "general-landing" });
+          })
+          .catch(() => {
+            unsetClientData();
+            return next({ name: "general-landing" });
+          });
+      } else if (accountType == 1) {
+        adminLogout()
+          .then(() => {
+            unsetClientData();
+            return next({ name: "general-admin-login" });
+          })
+          .catch(() => {
+            unsetClientData();
+            return next({ name: "general-admin-login" });
+          });
+      }
     } else if (from.name == "user-confirm" && !hasBeenActivated) {
       return next({ name: "user-confirm" });
     } else if (shouldBePrevented(to.name)) {

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -17,7 +17,7 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-surveys" */ "@views/user/surveys/SurveysView.vue"
-        )
+        ),
     },
     {
       path: "/user/surveys/:id/edit",
@@ -25,7 +25,7 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-survey-edit" */ "@views/user/survey-edit/SurveyEditView.vue"
-        )
+        ),
     },
     {
       path: "/user/surveys/:id/",
@@ -33,7 +33,7 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-survey-detail" */ "@views/user/survey-detail/SurveyDetailView.vue"
-        )
+        ),
     },
     {
       path: "/user/settings",
@@ -41,7 +41,7 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-settings" */ "@views/user/settings/SettingsView.vue"
-        )
+        ),
     },
     {
       path: "/user/confirm",
@@ -49,9 +49,9 @@ const userRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "user-confirm" */ "@views/user/login-confirm/LoginConfirmView.vue"
-        )
-    }
-  ])
+        ),
+    },
+  ]),
 ];
 
 const adminRoutes = [
@@ -62,7 +62,7 @@ const adminRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "admin-surveys" */ "@views/admin/surveys/SurveysView.vue"
-        )
+        ),
     },
     {
       path: "/admin/users",
@@ -70,7 +70,7 @@ const adminRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "admin-users" */ "@views/admin/users/UsersView.vue"
-        )
+        ),
     },
     {
       path: "/admin/settings",
@@ -78,9 +78,9 @@ const adminRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "admin-settings" */ "@views/admin/settings/SettingsView.vue"
-        )
-    }
-  ])
+        ),
+    },
+  ]),
 ];
 
 const generalRoutes = [
@@ -91,7 +91,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-landing" */ "@views/general/landing/LandingView.vue"
-        )
+        ),
     },
     {
       path: "/privacy-policy",
@@ -99,7 +99,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-privacy-policy" */ "@views/general/privacy-policy/PrivacyPolicyView.vue"
-        )
+        ),
     },
     {
       path: "/terms-and-conditions",
@@ -107,7 +107,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-terms-and-conditions" */ "@views/general/terms-and-conditions/TermsAndConditionsView.vue"
-        )
+        ),
     },
     {
       path: "/user/login",
@@ -116,7 +116,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-user-login" */ "@views/user/login/LoginView.vue"
-        )
+        ),
     },
     {
       path: "/user/signup",
@@ -124,7 +124,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-user-signup" */ "@views/user/signup/SignupView.vue"
-        )
+        ),
     },
     {
       path: "/admin/login",
@@ -132,7 +132,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-admin-login" */ "@views/admin/login/LoginView.vue"
-        )
+        ),
     },
     {
       path: "/survey/:id",
@@ -140,7 +140,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-survey-fill" */ "@views/general/survey-fill/SurveyFillView.vue"
-        )
+        ),
     },
     {
       path: "/user/signup/thankyou",
@@ -148,7 +148,7 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-user-signup-thankyou" */ "@views/user/signup-thankyou/SignupThankyouView.vue"
-        )
+        ),
     },
     {
       path: "/user/delete/thankyou",
@@ -156,10 +156,10 @@ const generalRoutes = [
       component: () =>
         import(
           /* webpackChunkName: "general-user-delete-thankyou" */ "@views/user/delete-thankyou/DeleteThankyouView.vue"
-        )
+        ),
     },
-    { path: "/logout", name: "general-logout" }
-  ])
+    { path: "/logout", name: "general-logout" },
+  ]),
 ];
 
 const router = new Router({
@@ -177,9 +177,9 @@ const router = new Router({
     ...adminRoutes,
     layout("DefaultWithoutSidebar", [
       { path: "/404", name: "general-404", component: PageNotFoundView },
-      { path: "*", redirect: "404" }
-    ])
-  ]
+      { path: "*", redirect: "404" },
+    ]),
+  ],
 });
 
 router.beforeEach((to, from, next) => {
@@ -190,7 +190,7 @@ router.beforeEach((to, from, next) => {
   const userMainPage = { name: "user-surveys" };
   const adminMainPage = { name: "admin-users" };
 
-  const preventedWords = [ "landing", "login", "signup", "delete" ];
+  const preventedWords = ["landing", "login", "signup", "delete"];
   const shouldBePrevented = (routeName) => {
     return preventedWords.some((preventedWord) =>
       routeName.includes(preventedWord)

--- a/ui/src/views/admin/login/LoginView.vue
+++ b/ui/src/views/admin/login/LoginView.vue
@@ -81,8 +81,10 @@
 </template>
 
 <script>
+import { adminLogin } from "@api";
+
 export default {
-  name: "LoginView",
+  name: "AdminLoginView",
   data() {
     return {
       isFormValid: false,
@@ -95,19 +97,18 @@ export default {
   },
   methods: {
     onFormSubmit() {
-      // get submission with this.formData
-      // submit form
-      // get auth key
-      // save to vuex
-      const userData = {
-        accountType: 1,
-        email: "admin@email.com"
-      };
-      this.$store.dispatch("user/setToken", "test");
-      this.$store.dispatch("user/setUserData", userData);
-      this.$store.dispatch("user/checkAccountTypeAndSetMenuItems");
-
-      this.$router.push({ name: "admin-users" });
+      adminLogin(this.formData).then((response) => {
+        const authKey = response["message"].split("Access token is ")[1];
+        const userData = {
+          accountType: 1,
+          email: this.formData.email
+        };
+        this.$cookies.set("access_token_cookie", authKey);
+        this.$store.dispatch("user/setToken", authKey);
+        this.$store.dispatch("user/setUserData", userData);
+        this.$store.dispatch("user/checkAccountTypeAndSetMenuItems");
+        this.$router.push({ name: "admin-users" });
+      });
     }
   }
 };

--- a/ui/src/views/admin/settings/SettingsView.vue
+++ b/ui/src/views/admin/settings/SettingsView.vue
@@ -139,10 +139,10 @@ export default {
   },
   methods: {
     onFormSubmit() {
-      const apiData = { new_password: this.formData.new_password };
-      adminChangePassword(apiData).then((response) => {
-        this.$notify.toast(response["message"]);
-      });
+      adminChangePassword({ new_password: this.formData.new_password })
+        .then((response) => {
+          this.$notify.toast(response["message"]);
+        });
     }
   }
 };

--- a/ui/src/views/admin/settings/SettingsView.vue
+++ b/ui/src/views/admin/settings/SettingsView.vue
@@ -60,7 +60,7 @@
                         rules="required|min:8"
                       >
                         <v-text-field
-                          v-model.trim="formData.password"
+                          v-model.trim="formData.new_password"
                           outlined
                           required
                           hint="Minimum 8 characters"
@@ -114,6 +114,7 @@
 
 <script>
 import { mapGetters } from "vuex";
+import { adminChangePassword } from "@api";
 
 export default {
   name: "AdminSettingsView",
@@ -123,7 +124,7 @@ export default {
       isPasswordShown: false,
       formData: {
         email: "",
-        password: ""
+        new_password: ""
       }
     };
   },
@@ -133,13 +134,15 @@ export default {
       return this.userData.email;
     },
     isPasswordLengthOkay() {
-      return this.formData.password.length >= 8;
+      return this.formData.new_password.length >= 8;
     }
   },
   methods: {
     onFormSubmit() {
       // to do: post form data to back-end's update admin api
-      this.$notify.toast("New settings have been saved!");
+      adminChangePassword(this.formData).then((response) => {
+        this.$notify.toast(response["message"]);
+      });
     }
   }
 };

--- a/ui/src/views/admin/settings/SettingsView.vue
+++ b/ui/src/views/admin/settings/SettingsView.vue
@@ -139,8 +139,8 @@ export default {
   },
   methods: {
     onFormSubmit() {
-      // to do: post form data to back-end's update admin api
-      adminChangePassword(this.formData).then((response) => {
+      const apiData = { new_password: this.formData.new_password };
+      adminChangePassword(apiData).then((response) => {
         this.$notify.toast(response["message"]);
       });
     }

--- a/ui/src/views/admin/users/UsersView.vue
+++ b/ui/src/views/admin/users/UsersView.vue
@@ -525,10 +525,9 @@ export default {
       const apiData = { email: this.selectedUser.email };
       adminUnblockUser(apiData).then((response) => {
         this.$notify.toast(response["message"]);
-        this.isAccountUnblockModalShown = false;
         this.getUsersApi();
         this.processUserData();
-        this.isAccountBlockModalShown = false;
+        this.isAccountUnblockModalShown = false;
         this.isEditItemModalShown = false;
       }).catch(() => {
         this.onAccountUnblockCancelation();

--- a/ui/src/views/admin/users/UsersView.vue
+++ b/ui/src/views/admin/users/UsersView.vue
@@ -473,9 +473,10 @@ export default {
       const apiData = { email: this.selectedUser.email };
       adminDeleteUser(apiData).then((response) => {
         this.$notify.toast(response["message"]);
-        this.isDeleteItemModalShown = false;
-        window.location.reload();
+        this.getUsersApi();
+        this.processUserData();
       });
+      this.isDeleteItemModalShown = false;
     },
     onClickCloseEditModal() {
       this.isEditItemModalShown = false;
@@ -491,9 +492,11 @@ export default {
       const apiData = { email: this.selectedUser.email };
       adminActivateUser(apiData).then((response) => {
         this.$notify.toast(response["message"]);
-        this.isAccountActivationModalShown = false;
-        window.location.reload();
+        this.getUsersApi();
+        this.processUserData();
       });
+      this.isAccountActivationModalShown = false;
+      this.isEditItemModalShown = false;
     },
     toggleSelectedUserIsBlocked() {
       if (!this.selectedUser.isBlocked) {
@@ -506,8 +509,12 @@ export default {
       const apiData = { email: this.selectedUser.email };
       adminBlockUser(apiData).then((response) => {
         this.$notify.toast(response["message"]);
+        this.getUsersApi();
+        this.processUserData();
         this.isAccountBlockModalShown = false;
-        window.location.reload();
+        this.isEditItemModalShown = false;
+      }).catch(() => {
+        this.onAccountBlockCancelation();
       });
     },
     onAccountBlockCancelation() {
@@ -519,7 +526,12 @@ export default {
       adminUnblockUser(apiData).then((response) => {
         this.$notify.toast(response["message"]);
         this.isAccountUnblockModalShown = false;
-        window.location.reload();
+        this.getUsersApi();
+        this.processUserData();
+        this.isAccountBlockModalShown = false;
+        this.isEditItemModalShown = false;
+      }).catch(() => {
+        this.onAccountUnblockCancelation();
       });
     },
     onAccountUnblockCancelation() {
@@ -533,9 +545,11 @@ export default {
       const apiData = { email: this.selectedUser.email };
       adminResetUserPassword(apiData).then((response) => {
         this.$notify.toast(response["message"]);
-        this.isResetPasswordModalShown = false;
-        window.location.reload();
+        this.getUsersApi();
+        this.processUserData();
       });
+      this.isResetPasswordModalShown = false;
+      this.isEditItemModalShown = false;
     },
     processUserData() {
       this.users = this.users.map((user, index) => {

--- a/ui/src/views/admin/users/UsersView.vue
+++ b/ui/src/views/admin/users/UsersView.vue
@@ -180,6 +180,7 @@
               <modal
                 v-model="isEditItemModalShown"
                 name="edit-modal"
+                :is-footer-shown="false"
               >
                 <template #default>
                   <v-card-title>
@@ -308,6 +309,8 @@
               <modal
                 v-model="isAccountBlockModalShown"
                 name="account-block-modal"
+                :is-close-button-shown="false"
+                :is-footer-shown="false"
               >
                 <template #default>
                   <v-card-title>
@@ -348,6 +351,8 @@
               <modal
                 v-model="isAccountUnblockModalShown"
                 name="account-unblock-modal"
+                :is-close-button-shown="false"
+                :is-footer-shown="false"
               >
                 <template #default>
                   <v-card-title>
@@ -422,14 +427,6 @@ export default {
       isResetPasswordModalShown: false,
       selectedUser: {},
       users: []
-        /*
-        {
-          id: 1,
-          email: "ayam@bebek.angsa",
-          isActivated: true,
-          isBlocked: false
-        }
-        */
     };
   },
   computed: {
@@ -468,6 +465,10 @@ export default {
   },
   mounted() {},
   methods: {
+    onClickItemDelete(item) {
+      this.selectedUser = { ...item };
+      this.isDeleteItemModalShown = true;
+    },
     onDeleteConfirmation() {
       const apiData = { email: this.selectedUser.email };
       adminDeleteUser(apiData).then((response) => {
@@ -475,10 +476,6 @@ export default {
         this.isDeleteItemModalShown = false;
         window.location.reload();
       });
-    },
-    onClickItemDelete(item) {
-      this.selectedUser = { ...item };
-      this.isDeleteItemModalShown = true;
     },
     onClickCloseEditModal() {
       this.isEditItemModalShown = false;
@@ -494,8 +491,9 @@ export default {
       const apiData = { email: this.selectedUser.email };
       adminActivateUser(apiData).then((response) => {
         this.$notify.toast(response["message"]);
+        this.isAccountActivationModalShown = false;
+        window.location.reload();
       });
-      this.isAccountActivationModalShown = false;
     },
     toggleSelectedUserIsBlocked() {
       if (!this.selectedUser.isBlocked) {
@@ -508,8 +506,9 @@ export default {
       const apiData = { email: this.selectedUser.email };
       adminBlockUser(apiData).then((response) => {
         this.$notify.toast(response["message"]);
+        this.isAccountBlockModalShown = false;
+        window.location.reload();
       });
-      this.isAccountBlockModalShown = false;
     },
     onAccountBlockCancelation() {
       this.selectedUser.isBlocked = (this.selectedUser.isBlocked)? false : true;
@@ -519,8 +518,9 @@ export default {
       const apiData = { email: this.selectedUser.email };
       adminUnblockUser(apiData).then((response) => {
         this.$notify.toast(response["message"]);
+        this.isAccountUnblockModalShown = false;
+        window.location.reload();
       });
-      this.isAccountUnblockModalShown = false;
     },
     onAccountUnblockCancelation() {
       this.selectedUser.isBlocked = (this.selectedUser.isBlocked)? false : true;
@@ -533,8 +533,9 @@ export default {
       const apiData = { email: this.selectedUser.email };
       adminResetUserPassword(apiData).then((response) => {
         this.$notify.toast(response["message"]);
+        this.isResetPasswordModalShown = false;
+        window.location.reload();
       });
-      this.isResetPasswordModalShown = false;
     },
     processUserData() {
       this.users = this.users.map((user, index) => {

--- a/ui/src/views/admin/users/UsersView.vue
+++ b/ui/src/views/admin/users/UsersView.vue
@@ -586,9 +586,6 @@ export default {
             }
             this.users.push(rawUser);
           });
-        })
-        .catch((error) => {
-          console.log(error);
         });
     }
   }

--- a/ui/src/views/admin/users/UsersView.vue
+++ b/ui/src/views/admin/users/UsersView.vue
@@ -403,7 +403,10 @@
 
 <script>
 import { get, sync } from "vuex-pathify";
-import { adminListUsers } from "@api";
+import {
+  adminListUsers, adminResetUserPassword, adminActivateUser,
+  adminBlockUser, adminUnblockUser, adminDeleteUser
+} from "@api";
 
 export default {
   name: "AdminUsersView",
@@ -460,19 +463,18 @@ export default {
     }
   },
   created() {
-    // get user api
-    // add certain columns to user data
     this.getUsersApi();
     this.processUserData();
   },
   mounted() {},
   methods: {
     onDeleteConfirmation() {
-      // call delete api
-      // delete
-      // refresh table
-      // hide modal
-      this.isDeleteItemModalShown = false;
+      const apiData = { email: this.selectedUser.email };
+      adminDeleteUser(apiData).then((response) => {
+        this.$notify.toast(response["message"]);
+        this.isDeleteItemModalShown = false;
+        window.location.reload();
+      });
     },
     onClickItemDelete(item) {
       this.selectedUser = { ...item };
@@ -482,10 +484,6 @@ export default {
       this.isEditItemModalShown = false;
     },
     onClickItemEdit(item) {
-      //show modal with toggle for activation,
-      //toggle for blocking,
-      //button for sending reset password link
-      console.log(item);
       this.selectedUser = { ...item };
       this.isEditItemModalShown = true;
     },
@@ -493,7 +491,10 @@ export default {
       this.isAccountActivationModalShown = true;
     },
     onAccountActivationConfirmation() {
-      // to do: api call for update isActivated status
+      const apiData = { email: this.selectedUser.email };
+      adminActivateUser(apiData).then((response) => {
+        this.$notify.toast(response["message"]);
+      });
       this.isAccountActivationModalShown = false;
     },
     toggleSelectedUserIsBlocked() {
@@ -504,7 +505,10 @@ export default {
       }
     },
     onAccountBlockConfirmation() {
-      // to do: api call for update isBlocked=1 status
+      const apiData = { email: this.selectedUser.email };
+      adminBlockUser(apiData).then((response) => {
+        this.$notify.toast(response["message"]);
+      });
       this.isAccountBlockModalShown = false;
     },
     onAccountBlockCancelation() {
@@ -512,7 +516,10 @@ export default {
       this.isAccountBlockModalShown = false;
     },
     onAccountUnblockConfirmation() {
-      // to do: api call for update isBlocked=0 status
+      const apiData = { email: this.selectedUser.email };
+      adminUnblockUser(apiData).then((response) => {
+        this.$notify.toast(response["message"]);
+      });
       this.isAccountUnblockModalShown = false;
     },
     onAccountUnblockCancelation() {
@@ -523,7 +530,10 @@ export default {
       this.isResetPasswordModalShown = true;
     },
     onResetPasswordConfirmation() {
-      // to do: api call for resetting user password
+      const apiData = { email: this.selectedUser.email };
+      adminResetUserPassword(apiData).then((response) => {
+        this.$notify.toast(response["message"]);
+      });
       this.isResetPasswordModalShown = false;
     },
     processUserData() {
@@ -563,8 +573,6 @@ export default {
     getUsersApi() {
       adminListUsers()
         .then((response) => {
-          console.log(response);
-
           this.users.length = 0;
           const rawUsers = response["users"];
           const rawUserIds = Object.keys(rawUsers);

--- a/ui/src/views/admin/users/UsersView.vue
+++ b/ui/src/views/admin/users/UsersView.vue
@@ -403,7 +403,7 @@
 
 <script>
 import { get, sync } from "vuex-pathify";
-import { getUsers } from "@api";
+import { adminListUsers } from "@api";
 
 export default {
   name: "AdminUsersView",
@@ -418,26 +418,15 @@ export default {
       isAccountUnblockModalShown: false,
       isResetPasswordModalShown: false,
       selectedUser: {},
-      users: [
+      users: []
+        /*
         {
           id: 1,
           email: "ayam@bebek.angsa",
           isActivated: true,
           isBlocked: false
-        },
-        {
-          id: 2,
-          email: "sadBoy123@pevuer.pl",
-          isActivated: false,
-          isBlocked: true
-        },
-        {
-          id: 3,
-          email: "lifeIsHard456@gmail.pl",
-          isActivated: true,
-          isBlocked: true
         }
-      ]
+        */
     };
   },
   computed: {
@@ -473,6 +462,7 @@ export default {
   created() {
     // get user api
     // add certain columns to user data
+    this.getUsersApi();
     this.processUserData();
   },
   mounted() {},
@@ -570,40 +560,23 @@ export default {
       }
       return item;
     },
-    getUserApi() {
-      // example of fetching api directly with fetch
-      fetch("http://localhost:8000")
-        .then((response) => response.json())
-        .then((data) => {
-          this.message = data.message;
-        })
-        .catch((error) => {
-          console.log(error);
-        });
-
-      // example 1 with axios
-      this.$axios
-        .get("https://api.coindesk.com/v1/bpi/currentprice.json")
-        .then((response) => {
-          if (response.status == 200) {
-            // do something
-          } else {
-            // error
-            // do something
-          }
-        })
-        .catch((error) => {
-          // do something on error
-          console.error(error);
-        });
-
-      // example 2
-      // recommended because this way the api is centered in one place/file
-      // dont forget to handle errors
-      getUsers()
+    getUsersApi() {
+      adminListUsers()
         .then((response) => {
           console.log(response);
-          // do something with the response
+
+          this.users.length = 0;
+          const rawUsers = response["users"];
+          const rawUserIds = Object.keys(rawUsers);
+          rawUserIds.forEach(rawUserid => {
+            let rawUser = {
+              id: rawUserid,
+              email: rawUsers[rawUserid]["user_email"],
+              isActivated: rawUsers[rawUserid]["user_activated"],
+              isBlocked: rawUsers[rawUserid]["user_blocked"]
+            }
+            this.users.push(rawUser);
+          });
         })
         .catch((error) => {
           console.log(error);


### PR DESCRIPTION
Successfully connected APIs between FE and BE for admin login, admin logout, admin change password, admin activate user, admin block user, admin unblock user, admin reset user password, admin delete user.

What's changed:
- ui/package.json : fixed the spacing
- ui/src/api/index.js : added api urls and api functions
- ui/src/router/index.js : in logout mechanism, added account type checking to determine which api function to call (userLogout or adminLogout) and where to redirect (user => main home page, admin => admin login page)
- ui/src/views/admin/login/LoginView.vue : changed export name to AdminLoginView, added api call for admin login
- ui/src/views/admin/settings/SettingsView.vue : added api call for admin change password
- ui/src/views/admin/users/UsersView.vue : added props in some modals to hide close button and footer, added api calls for user management

To do:
- implement getSurveys on admin side (may need to ask BE to create the function to allow admin to get all surveys, but i will check first if i can use any existing function for that)
- deleteSurvey api call on admin side; the function has been added into api function list but not yet added to the View because the page can't get all surveys from db yet
- implement api calls for surveys and responses