### PR TITLE
feat: added user survey apis

### DIFF
--- a/ui/.env.development
+++ b/ui/.env.development
@@ -1,3 +1,2 @@
 NODE_ENV="development"
-VUE_APP_API_BASE_URL="http://localhost:8000/api/"
-VUE_APP_IFRAME_BASE_URL="http://localhost:8000/"
+VUE_APP_API_BASE_URL="http://localhost:8000/"

--- a/ui/.env.development
+++ b/ui/.env.development
@@ -1,2 +1,3 @@
 NODE_ENV="development"
 VUE_APP_API_BASE_URL="http://localhost:8000/api/"
+VUE_APP_IFRAME_BASE_URL="http://localhost:8000/"

--- a/ui/.env.production
+++ b/ui/.env.production
@@ -1,3 +1,2 @@
 NODE_ENV="production"
-VUE_APP_API_BASE_URL="http://localhost:8000/api/"
-VUE_APP_IFRAME_BASE_URL="http://localhost:8000/"
+VUE_APP_API_BASE_URL="http://localhost:8000/"

--- a/ui/.env.production
+++ b/ui/.env.production
@@ -1,2 +1,3 @@
 NODE_ENV="production"
 VUE_APP_API_BASE_URL="http://localhost:8000/api/"
+VUE_APP_IFRAME_BASE_URL="http://localhost:8000/"

--- a/ui/src/api/config.js
+++ b/ui/src/api/config.js
@@ -1,7 +1,7 @@
 /* global VUE_APP_API_BASE_URL */
 
 export default {
-  baseURL: VUE_APP_API_BASE_URL,
+  baseURL: VUE_APP_API_BASE_URL + "api/",
   timeout: 30000,
   common: {
     Accept: "application/json",

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -40,8 +40,6 @@ axios.interceptors.response.use(
   }
 );
 
-const GET_SURVEYS_URL = "user/surveys";
-const ADD_SURVEY_URL = "user/surveys";
 const USER_SIGNUP_URL = "authentication/signup";
 const USER_LOGIN_URL = "authentication/login";
 const USER_LOGOUT_URL = "authentication/logout";
@@ -53,6 +51,7 @@ const USER_DELETE_ACCOUNT_URL = "user/delete";
 const ADMIN_LOGIN_URL = "admin/login";
 const ADMIN_LOGOUT_URL = "admin/logout";
 const ADMIN_CHANGE_PASSWORD_URL = "admin/changepassword";
+//const ADMIN_LIST_SURVEYS_URL = "";
 const ADMIN_DELETE_SURVEY_URL = "admin/deletesurvey";
 const ADMIN_LIST_USERS_URL = "admin/listusers";
 const ADMIN_SEARCH_USER_URL = "admin/searchuser";
@@ -62,13 +61,45 @@ const ADMIN_BLOCK_USER_URL = "admin/blockuser";
 const ADMIN_UNBLOCK_USER_URL = "admin/unblockeduser";
 const ADMIN_DELETE_USER_URL = "admin/deleteuser";
 
-export const getSurveys = () => {
-  return axios.get(GET_SURVEYS_URL);
+const USER_LIST_SURVEYS_URL = "user/surveys";
+const USER_DELETE_SURVEY_URL = "user/survey/delete";
+const USER_ADD_SURVEY_URL = "survey/add";
+const USER_EDIT_SURVEY_URL = "";
+const USER_GET_SURVEY_URL = "survey/";
+const USER_SURVEY_DATATABLE_URL = "analysis/generatedatatable/";
+const USER_SURVEY_SUMMARY_URL = "analysis/getsummary/";
+
+
+
+export const userListSurveys = () => {
+  return axios.get(USER_LIST_SURVEYS_URL);
 };
 
-export const addSurvey = (data) => {
-  return axios.post(ADD_SURVEY_URL, data);
+export const userDeleteSurvey = (data) => {
+  return axios.post(USER_DELETE_SURVEY_URL, data);
 };
+
+export const userAddSurvey = (data) => {
+  return axios.post(USER_ADD_SURVEY_URL, data);
+};
+
+export const userEditSurvey = (data) => {
+  return axios.post(USER_EDIT_SURVEY_URL, data);
+};
+
+export const userGetSurvey = (survey_id) => {
+  return axios.get(USER_GET_SURVEY_URL + survey_id);
+};
+
+export const userGetSurveyDatatable = (survey_id) => {
+  return axios.get(USER_SURVEY_DATATABLE_URL + survey_id);
+};
+
+export const userGetSurveySummary = (survey_id) => {
+  return axios.get(USER_SURVEY_SUMMARY_URL + survey_id);
+};
+
+
 
 export const userSignup = (data) => {
   return axios.post(USER_SIGNUP_URL, data);

--- a/ui/src/util/dates.js
+++ b/ui/src/util/dates.js
@@ -9,6 +9,14 @@ export const convertToStandardDate = function (
   return moment(value, givenFormat).format("DD MMM YYYY");
 };
 
+export const isTodayAfterGivenDate = function (
+  givenDate,
+  givenDateFormat = pythonDefaultDateFormat
+) {
+  return moment().isAfter(moment(givenDate, givenDateFormat));
+};
+
+// from moment.js documentation: moment().isBefore() has undefined behavior and should not be used!
 export const isTodayBeforeGivenDate = function (
   givenDate,
   givenDateFormat = pythonDefaultDateFormat

--- a/ui/src/util/dates.js
+++ b/ui/src/util/dates.js
@@ -16,12 +16,11 @@ export const isTodayAfterGivenDate = function (
   return moment().isAfter(moment(givenDate, givenDateFormat));
 };
 
-// from moment.js documentation: moment().isBefore() has undefined behavior and should not be used!
 export const isTodayBeforeGivenDate = function (
   givenDate,
   givenDateFormat = pythonDefaultDateFormat
 ) {
-  return moment().isBefore(moment(givenDate, givenDateFormat));
+  return moment().isSameOrBefore(moment(givenDate, givenDateFormat));
 };
 
 export const getDurationFromTodayToGivenDate = function (

--- a/ui/src/views/user/survey-detail/components/DetailResponses.vue
+++ b/ui/src/views/user/survey-detail/components/DetailResponses.vue
@@ -67,11 +67,11 @@ export default {
     getSurveyDatatableApi(surveyId) {
       this.$notify.toast("Preparing data...");
       userGetSurveyDatatable(surveyId).then(() => {
-        this.responsesUrl = "http://localhost:8000/dash_datatable/";
+        this.responsesUrl = process.env.VUE_APP_IFRAME_BASE_URL + "dash_datatable/";
       });
     },
     onLoadIframe() {
-      this.$notify.toast("Responses sucessfully loaded.");
+      this.$notify.toast("Responses successfully loaded.");
     }
   }
 };

--- a/ui/src/views/user/survey-detail/components/DetailResponses.vue
+++ b/ui/src/views/user/survey-detail/components/DetailResponses.vue
@@ -67,7 +67,7 @@ export default {
     getSurveyDatatableApi(surveyId) {
       this.$notify.toast("Preparing data...");
       userGetSurveyDatatable(surveyId).then(() => {
-        this.responsesUrl = process.env.VUE_APP_IFRAME_BASE_URL + "dash_datatable/";
+        this.responsesUrl = process.env.VUE_APP_API_BASE_URL + "dash_datatable/";
       });
     },
     onLoadIframe() {

--- a/ui/src/views/user/survey-detail/components/DetailResponses.vue
+++ b/ui/src/views/user/survey-detail/components/DetailResponses.vue
@@ -10,7 +10,7 @@
         class="mt-2"
       >
         <v-col
-          cols="7"
+          cols="12"
           class="text-left detail-responses__info"
         >
           <h1 class="title">
@@ -19,23 +19,6 @@
           <p class="ma-0 description text-secondary">
             {{ survey.data.description }}
           </p>
-        </v-col>
-        <v-col
-          cols="5"
-          class="text-right"
-        >
-          <v-btn
-            :block="isMobile"
-            small
-            height="44"
-            class="v-btn--accent"
-            @click="onClickDownloadButton"
-          >
-            <v-icon class="pr-1">
-              mdi-download
-            </v-icon>
-            DOWNLOAD AS CSV
-          </v-btn>
         </v-col>
         <v-col
           cols="12"
@@ -52,14 +35,13 @@
 </template>
 
 <script>
-import surveyDataSample from "@/assets/json/survey-data-sample.json";
+import { userGetSurveyDatatable } from "@api";
 
 export default {
   name: "DetailResponses",
   data() {
     return {
-      keyword: "",
-      responsesUrl: "http://localhost:8000/",
+      responsesUrl: "",
       survey: {
         data: {
           title: "",
@@ -73,17 +55,23 @@ export default {
       }
     };
   },
+  computed: {
+    surveyId() {
+      return this.$route.params.id;
+    }
+  },
   created() {
-    this.survey = { ...this.survey, ...surveyDataSample };
+    this.getSurveyDatatableApi(this.surveyId);
   },
   methods: {
-    onClickDownloadButton() {
-      // do something
-      // fetch the api
-      this.$notify.toast("File has been downloaded");
+    getSurveyDatatableApi(surveyId) {
+      this.$notify.toast("Preparing data...");
+      userGetSurveyDatatable(surveyId).then(() => {
+        this.responsesUrl = "http://localhost:8000/dash_datatable/";
+      });
     },
     onLoadIframe() {
-      // do something
+      this.$notify.toast("Responses sucessfully loaded.");
     }
   }
 };

--- a/ui/src/views/user/survey-detail/components/DetailSummary.vue
+++ b/ui/src/views/user/survey-detail/components/DetailSummary.vue
@@ -16,11 +16,13 @@
 </template>
 
 <script>
+import { userGetSurveySummary } from "@api";
+
 export default {
   name: "DetailSummary",
   data() {
     return {
-      summaryUrl: "http://localhost:8080/"
+      summaryUrl: ""
     };
   },
   computed: {
@@ -29,16 +31,17 @@ export default {
     }
   },
   created() {
-    this.getSurveySummary();
+    this.getSurveySummaryApi(this.surveyId);
   },
   methods: {
-    onLoadSummaryPage() {
-      // do something
+    getSurveySummaryApi(surveyId) {
+      this.$notify.toast("Preparing data...");
+      userGetSurveySummary(surveyId).then(() => {
+        this.summaryUrl = "http://localhost:8000/dashboard/";
+      });
     },
-    getSurveySummary() {
-      // get survey summary by id
-      // assign to summaryUrl
-      // load
+    onLoadSummaryPage() {
+      this.$notify.toast("Stats summary loaded successfully.");
     }
   }
 };

--- a/ui/src/views/user/survey-detail/components/DetailSummary.vue
+++ b/ui/src/views/user/survey-detail/components/DetailSummary.vue
@@ -37,7 +37,7 @@ export default {
     getSurveySummaryApi(surveyId) {
       this.$notify.toast("Preparing data...");
       userGetSurveySummary(surveyId).then(() => {
-        this.summaryUrl = process.env.VUE_APP_IFRAME_BASE_URL + "dashboard/";
+        this.summaryUrl = process.env.VUE_APP_API_BASE_URL + "dashboard/";
       });
     },
     onLoadSummaryPage() {

--- a/ui/src/views/user/survey-detail/components/DetailSummary.vue
+++ b/ui/src/views/user/survey-detail/components/DetailSummary.vue
@@ -37,7 +37,7 @@ export default {
     getSurveySummaryApi(surveyId) {
       this.$notify.toast("Preparing data...");
       userGetSurveySummary(surveyId).then(() => {
-        this.summaryUrl = "http://localhost:8000/dashboard/";
+        this.summaryUrl = process.env.VUE_APP_IFRAME_BASE_URL + "dashboard/";
       });
     },
     onLoadSummaryPage() {

--- a/ui/src/views/user/survey-edit/SurveyEditView.vue
+++ b/ui/src/views/user/survey-edit/SurveyEditView.vue
@@ -303,9 +303,6 @@ export default {
         .then((response) => {
           console.log(JSON.stringify(response));
           // how to load the response into the formData?
-        })
-        .catch((error) => {
-          console.log(error);
         });
     }
   }

--- a/ui/src/views/user/survey-edit/SurveyEditView.vue
+++ b/ui/src/views/user/survey-edit/SurveyEditView.vue
@@ -143,6 +143,7 @@
 
 <script>
 import { EventBus } from "@/util/event-bus";
+import { userGetSurvey, userAddSurvey, userEditSurvey } from "@api";
 
 export default {
   name: "SurveyEditView",
@@ -173,6 +174,7 @@ export default {
       isBottomSheetShown: false,
       bottomSheetContent: "surveyElements", // surveyElements, settings
       activeSurveyEditTab: 0,
+      currentSurveyId: "new",
       formData: {
         data: {
           formBuilder: {
@@ -204,6 +206,13 @@ export default {
   },
   mounted() {
     this.mountListeners();
+  },
+  created() {
+    const surveyId = this.$route.params.id;
+    if (surveyId != "new") {
+      this.currentSurveyId = surveyId;
+      this.getSurveyApi(surveyId);
+    }
   },
   beforeDestroy() {
     this.destroyListeners();
@@ -240,22 +249,60 @@ export default {
       return this.formData;
     },
     onSaveAsDraftOptionClick() {
+      console.log("save as draft");
       const finalOutput = this.getData();
       console.log(JSON.stringify(finalOutput));
 
-      this.$notify.toast("Survey has been successfully saved");
+      if(finalOutput.config.startDate == "" || finalOutput.config.endDate == "") {
+        this.$notify.toast("Please give survey's start date and end date!");
+      } else {
+        if (this.currentSurveyId == "new") {
+          userAddSurvey(finalOutput)
+          .then(() => {
+            this.$notify.toast("Your survey has been saved!");
+            this.$router.push("/user/surveys/");
+          }).catch((error) => {
+            this.$notify.toast(error["message"]);
+          });
+        } else {
+          finalOutput.config.id = this.currentSurveyId;
+          userEditSurvey(finalOutput)
+          .then(() => {
+            this.$notify.toast("Your survey has been saved!");
+            window.location.reload();
+          }).catch((error) => {
+            this.$notify.toast(error["message"]);
+          });
+        }
+      }
     },
     onSaveAndPublishOptionClick() {
       console.log("save and publish");
       const finalOutput = this.getData();
       console.log(JSON.stringify(finalOutput));
 
-      // call api
-      // save
-      // go to detail page
-
-      this.$notify.toast("Survey has been successfully published");
-      this.$router.push("/user/surveys/1");
+      if(finalOutput.config.startDate == "" || finalOutput.config.endDate == "") {
+        this.$notify.toast("Please give survey's start date and end date!");
+      } else {
+        if (this.currentSurveyId == "new") {
+          userAddSurvey(finalOutput)
+          .then(() => {
+            this.$notify.toast("Your survey has been published!");
+            this.$router.push("/user/surveys/");
+          }).catch((error) => {
+            this.$notify.toast(error["message"]);
+          });
+        } else {
+          finalOutput.config.id = this.currentSurveyId;
+          userEditSurvey(finalOutput)
+          .then(() => {
+            this.$notify.toast("Your survey has been published!");
+            this.$router.push("/user/surveys/");
+          }).catch((error) => {
+            this.$notify.toast(error["message"]);
+          });
+        }
+      }
     },
     onClickNewSurveyElementsButton() {
       this.isBottomSheetShown = true;
@@ -264,6 +311,18 @@ export default {
     onClickSettingsButton() {
       this.isBottomSheetShown = true;
       this.bottomSheetContent = "settings";
+    },
+    getSurveyApi(surveyId) {
+      console.log("running getSurveyApi() with param:");
+      console.log(surveyId);
+      userGetSurvey(surveyId)
+        .then((response) => {
+          console.log(JSON.stringify(response));
+          // how to load the response into the formData?
+        })
+        .catch((error) => {
+          console.log(error);
+        });
     }
   }
 };

--- a/ui/src/views/user/survey-edit/SurveyEditView.vue
+++ b/ui/src/views/user/survey-edit/SurveyEditView.vue
@@ -253,50 +253,34 @@ export default {
       const finalOutput = this.getData();
       console.log(JSON.stringify(finalOutput));
 
-      if(finalOutput.config.startDate == "" || finalOutput.config.endDate == "") {
-        this.$notify.toast("Please give survey's start date and end date!");
-      } else {
-        if (this.currentSurveyId == "new") {
-          userAddSurvey(finalOutput)
-          .then(() => {
-            this.$notify.toast("Your survey has been saved!");
-            this.$router.push("/user/surveys/");
-          }).catch((error) => {
-            this.$notify.toast(error["message"]);
-          });
-        } else {
-          finalOutput.config.id = this.currentSurveyId;
-          userEditSurvey(finalOutput)
-          .then(() => {
-            this.$notify.toast("Your survey has been saved!");
-            window.location.reload();
-          }).catch((error) => {
-            this.$notify.toast(error["message"]);
-          });
-        }
-      }
+      this.saveUserSurveyApi(finalOutput);
     },
     onSaveAndPublishOptionClick() {
       console.log("save and publish");
       const finalOutput = this.getData();
       console.log(JSON.stringify(finalOutput));
 
-      if(finalOutput.config.startDate == "" || finalOutput.config.endDate == "") {
+      this.saveUserSurveyApi(finalOutput);
+      // call api for publishing (sending email invitations) here
+    },
+    saveUserSurveyApi(finalOutput) {
+      const areEmptyStartEndDates = (finalOutput["config"]["startDate"] == "" || finalOutput["config"]["endDate"] == "");
+      if(areEmptyStartEndDates) {
         this.$notify.toast("Please give survey's start date and end date!");
       } else {
         if (this.currentSurveyId == "new") {
           userAddSurvey(finalOutput)
           .then(() => {
-            this.$notify.toast("Your survey has been published!");
+            this.$notify.toast("Your survey has been saved!");
             this.$router.push("/user/surveys/");
           }).catch((error) => {
             this.$notify.toast(error["message"]);
           });
         } else {
-          finalOutput.config.id = this.currentSurveyId;
+          finalOutput["config"]["id"] = this.currentSurveyId;
           userEditSurvey(finalOutput)
           .then(() => {
-            this.$notify.toast("Your survey has been published!");
+            this.$notify.toast("Your survey has been saved!");
             this.$router.push("/user/surveys/");
           }).catch((error) => {
             this.$notify.toast(error["message"]);


### PR DESCRIPTION
I don't include my changes to the BE code in this PR, to avoid conflicts with future BE PRs.

What's changed:
- ui/src/api/index.js : added survey apis
- ui/src/util/dates.js : added isAfter function which is more recommended than isBefore
- ui/src/views/user/survey-detail/components/DetailResponses.vue : embedded responses datatable iframe
- ui/src/views/user/survey-detail/components/DetailSummary.vue : embedded stats summary iframe
- ui/src/views/user/surveys/SurveysView.vue : added list surveys, delete survey api calls
- ui/src/views/user/survey-edit/SurveyEditView.vue : added create api call, edit mechanism still need to be implemented

To do:
implement mapping to load survey data on edit survey page, api call for edit survey, api call for publish survey, mapping for survey response page, api call for submit responses