### PR TITLE
fix: solved bugs with single choice question and opening response page

### DIFF
--- a/api/resources/survey.py
+++ b/api/resources/survey.py
@@ -133,13 +133,12 @@ class GetSurvey(Resource):
         surveyHash = request.args.get('hash', None)
         if not survey:
             return {'message': 'Such survey does not exist.'}, 403
-        if survey.is_published():
-            if survey.isPublic:
-                allow = True
-            else:
-                if surveyHash is not None:
-                    if surveyHash == survey.surveyHash:
-                        allow = True
+        if survey.isPublic:
+            allow = True
+        else:
+            if surveyHash is not None:
+                if surveyHash == survey.surveyHash:
+                    allow = True
         if not allow:
             return {'message': 'You are not allowed to access this survey.'}, 403
         survey_json = survey.get_json()

--- a/api/resources/survey.py
+++ b/api/resources/survey.py
@@ -127,30 +127,20 @@ class ListSurveysByUser(Resource):
 
 
 class GetSurvey(Resource):
-    @jwt_required(optional=True)
     def get(self, survey_id):
         allow = False
         survey = Survey.get_survey(survey_id)
         surveyHash = request.args.get('hash', None)
         if not survey:
             return {'message': 'Such survey does not exist.'}, 403
-        try:
-            current_user_id = get_jwt_identity()
-            if current_user_id is not None:
-                if not is_allowed(User.find_by_id(current_user_id)):
-                    return {'message': 'You are not allowed to access the website.'}, 403
-                if survey.surveyOwner == current_user_id:
-                    return jsonify(survey.get_json())
-        except Exception:
-            allow = False
         if survey.is_published():
-            if surveyHash is not None:
-                if surveyHash == survey.surveyHash:
-                    allow = True
             if survey.isPublic:
                 allow = True
+            else:
+                if surveyHash is not None:
+                    if surveyHash == survey.surveyHash:
+                        allow = True
         if not allow:
             return {'message': 'You are not allowed to access this survey.'}, 403
         survey_json = survey.get_json()
-        survey_json['config'] = dict()
         return jsonify(survey_json)

--- a/ui/src/views/general/survey-fill/SurveyFillView.vue
+++ b/ui/src/views/general/survey-fill/SurveyFillView.vue
@@ -176,9 +176,9 @@ export default {
         survey.config.endDate = new Date(survey.config.endDate);
         const todaysDate = new Date();
         if (survey.config.startDate <= todaysDate && todaysDate <= survey.config.endDate) {
-          survey.data.isPublished = true;
+          this.isPublished = true;
         } else {
-          survey.data.isPublished = false;
+          this.isPublished = false;
         }
         survey.data.formBuilder.list = survey.data.formBuilder.list.map(
           (listItem) => {

--- a/ui/src/views/general/survey-fill/SurveyFillView.vue
+++ b/ui/src/views/general/survey-fill/SurveyFillView.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="fill-height text-center survey-fill-view" tag="section">
     <v-row justify="center">
-      <v-col v-if="!survey.data.isPublished" cols="12">
+      <v-col v-if="!isPublished" cols="12">
         <content-card
           title="Sorry, this survey is not yet published"
           description="Check your invite link or make sure you are granted the right
@@ -103,6 +103,7 @@ export default {
     return {
       token: this.$route.query.token,
       todayDate: moment().format("DD MMM YYYY"),
+      isPublished: true,
       hasPermission: true,
       hasSubmitted: false,
       baseUrl: window.location.origin,
@@ -170,11 +171,21 @@ export default {
     getSurveyApi(survey_id) {
       userGetSurvey(survey_id).then((response) => {
         const survey = _.cloneDeep(response);
+        console.log(JSON.stringify(survey));
         survey.config.startDate = new Date(survey.config.startDate);
         survey.config.endDate = new Date(survey.config.endDate);
+        const todaysDate = new Date();
+        if (survey.config.startDate <= todaysDate && todaysDate <= survey.config.endDate) {
+          survey.data.isPublished = true;
+        } else {
+          survey.data.isPublished = false;
+        }
         survey.data.formBuilder.list = survey.data.formBuilder.list.map(
           (listItem) => {
             listItem.question = listItem.title;
+            if (listItem.model.includes("radio_")) {
+              listItem.type = "radio";
+            }
             return listItem;
           }
         );

--- a/ui/src/views/user/survey-detail/components/DetailQuestions.vue
+++ b/ui/src/views/user/survey-detail/components/DetailQuestions.vue
@@ -364,6 +364,9 @@ export default {
         survey.data.formBuilder.list = survey.data.formBuilder.list.map(
           (listItem) => {
             listItem.question = listItem.title;
+            if (listItem.model.includes("radio_")) {
+              listItem.type = "radio";
+            }
             return listItem;
           }
         );

--- a/ui/src/views/user/survey-edit/SurveyEditView.vue
+++ b/ui/src/views/user/survey-edit/SurveyEditView.vue
@@ -326,6 +326,9 @@ export default {
         survey.data.formBuilder.list = survey.data.formBuilder.list.map(
           (listItem) => {
             listItem.question = listItem.title;
+            if (listItem.model.includes("radio_")) {
+              listItem.type = "radio";
+            }
             return listItem;
           }
         );


### PR DESCRIPTION
Hey all, some bug fixes:
- bug where single choice becomes multiple choices after saving : problem is with python line `if multiple_choice_question.allowMultipleAnswers:` which doesn't work but i don't know why, as a quick fix i have added some check and mapping on FE to set the type back to radio
- bug where a visitor to response page cant see the survey without logging in : i have removed jwt checking from getsurvey api, so pretty much anybody can get survey data (which is fine; only surveyOwner can edit or delete survey anyway); also removed survey.is_published() check because the condition is handled on FE side
